### PR TITLE
ARTEMIS-1154 isolated backup fails over

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -298,25 +298,27 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    }
 
+   /**
+    * @return true if no checks were done or if one address/url responds; false if all addresses/urls fail
+    */
    public boolean check() {
-      boolean isEmpty = true;
+      if (isEmpty()) {
+         return true;
+      }
+
       for (InetAddress address : addresses) {
-         isEmpty = false;
          if (check(address)) {
             return true;
          }
       }
 
       for (URL url : urls) {
-         isEmpty = false;
          if (check(url)) {
             return true;
          }
       }
 
-      // This should return true if no checks were done, on this case it's empty
-      // This is tested by {@link NetworkHe
-      return isEmpty;
+      return false;
    }
 
    public boolean check(InetAddress address) {
@@ -396,5 +398,9 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
          logger.warn(e.getMessage(), e);
          return false;
       }
+   }
+
+   public boolean isEmpty() {
+      return addresses.isEmpty() && urls.isEmpty();
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/SharedNothingBackupQuorum.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/SharedNothingBackupQuorum.java
@@ -108,7 +108,7 @@ public class SharedNothingBackupQuorum implements Quorum, SessionFailureListener
             signal = BACKUP_ACTIVATION.FAIL_OVER;
          }
 
-         if (networkHealthCheck != null && networkHealthCheck.check()) {
+         if (networkHealthCheck != null && !networkHealthCheck.isEmpty() && networkHealthCheck.check()) {
             // live is assumed to be down, backup fails-over
             signal = BACKUP_ACTIVATION.FAIL_OVER;
          } else {


### PR DESCRIPTION
Even if there is no address/url configured for the NetworkHealthCheck
an isolated backup will still fail-over potentially causing split-brain.

(cherry picked from commit 5cb5c8a6dc7179078f099d5455343e1f18fd3398)

https://issues.jboss.org/browse/ENTMQBR-469