### PR TITLE
ENTMQBR-819 Upgrade Node.js version to comply with GitBook 3.2.3

### DIFF
--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -82,7 +82,7 @@
       <webapp-outdir-hacking-guide>${basedir}/target/classes/hacking-guide</webapp-outdir-hacking-guide>
 
       <frontend-maven-plugin-version>0.0.29</frontend-maven-plugin-version>
-      <nodeVersion>v0.10.32</nodeVersion>
+      <nodeVersion>v6.11.0</nodeVersion>
       <npmVersion>1.4.12</npmVersion>
 
    </properties>


### PR DESCRIPTION
ARTEMIS-1466 Node.JS version upgrade to fix GitBook 3.2.3 crash

(cherry picked from commit d99359d256496bc519b2c8f8705d82463214cd6f)