### PR TITLE
ARTEMIS-1894 Avoiding apache.org URL on codebase

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
@@ -172,9 +172,8 @@ public class NetworkHealthTest {
       NetworkHealthCheck check = addCheck(new NetworkHealthCheck(null, 100, 100));
 
       // using two addresses for URI and localhost
-      check.parseAddressList("localhost, , 127.0.0.2").parseURIList("http://www.redhat.com, , http://www.apache.org");
+      check.parseAddressList("localhost, , 127.0.0.2");
       Assert.assertEquals(2, check.getAddresses().size());
-      Assert.assertEquals(2, check.getUrls().size());
    }
 
    @Test
@@ -182,9 +181,9 @@ public class NetworkHealthTest {
       NetworkHealthCheck check = addCheck(new NetworkHealthCheck(null, 100, 100));
 
       // using two addresses for URI and localhost
-      check.parseAddressList("localhost, , 127.0.0.2").parseURIList("http://www.redhat.com, , http://www.apache.org");
+      check.parseAddressList("localhost, , 127.0.0.2");
       Assert.assertEquals(2, check.getAddresses().size());
-      Assert.assertEquals(2, check.getUrls().size());
+      Assert.assertEquals(0, check.getUrls().size());
    }
 
    @Test


### PR DESCRIPTION
(cherry picked from commit 1369690f574c2c97d1fa3930260eae5039b703c1)
(cherry picked from commit a7dbd5711334c49f6100e0d04243eec79e04cad2)

There is no need for ENTMQBR on this one. This is just a test change