### PR TITLE
ARTEMIS-2133 Artemis tab not showing on IE browser

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
@@ -362,7 +362,7 @@ var ARTEMIS = (function(ARTEMIS) {
 
       workspace.subLevelTabs = subLevelTabs;
 
-      preLogoutTasks.addTask("clearArtemisCredentials", () => {
+      preLogoutTasks.addTask("clearArtemisCredentials", function () {
           localStorage.removeItem('artemisUserName');
           localStorage.removeItem('artemisPassword');
       });


### PR DESCRIPTION
The web console on IE doesn't have 'Artemis' showed up because
it doesn't support javascripts => function.

(cherry picked from commit 7c699ff46bedb61c5e9193c39925bdd0ad881427)
(cherry picked from commit a7256372e26a3f1ad839bde93a6b73508ab8dfb6)

https://issues.jboss.org/browse/ENTMQBR-1880