### PR TITLE
ARTEMIS-2146 Avoiding NPE on AMQP Flow Control

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
@@ -349,7 +349,9 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
 
    @Override
    public HandleStatus handle(final MessageReference ref) throws Exception {
-      if (callback != null && !callback.hasCredits(this) || availableCredits != null && availableCredits.get() <= 0) {
+      // available credits can be set back to null with a flow control option.
+      AtomicInteger checkInteger = availableCredits;
+      if (callback != null && !callback.hasCredits(this) || checkInteger != null && checkInteger.get() <= 0) {
          if (logger.isDebugEnabled()) {
             logger.debug(this + " is busy for the lack of credits. Current credits = " +
                             availableCredits +


### PR DESCRIPTION
AMQP Flow control will disable consumer flow control (setting credits to null)
This will avoid a race checking flow control.

(cherry picked from commit 5132775371300de3a0c34e119d205f546f070c63)
(cherry picked from commit 0b0499b8a9a290d59525c0cd31b42f0695de7830)

downstream: https://issues.jboss.org/browse/ENTMQBR-2075