### PR TITLE
NO-JIRA Fix minor leak in FileMoveManagerTest

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
@@ -352,11 +352,12 @@ public class FileMoveManagerTest {
 
    private void checkFile(File bkpFolder, String file) throws IOException {
       File fileRead = new File(bkpFolder, file);
-      InputStreamReader stream = new InputStreamReader(new FileInputStream(fileRead));
-      BufferedReader reader = new BufferedReader(stream);
-      String valueRead = reader.readLine();
-      int id = Integer.parseInt(file.substring(0, file.indexOf('.')));
-      Assert.assertEquals("content of the file wasn't the expected", id, Integer.parseInt(valueRead));
+      try (InputStreamReader stream = new InputStreamReader(new FileInputStream(fileRead))) {
+         BufferedReader reader = new BufferedReader(stream);
+         String valueRead = reader.readLine();
+         int id = Integer.parseInt(file.substring(0, file.indexOf('.')));
+         Assert.assertEquals("content of the file wasn't the expected", id, Integer.parseInt(valueRead));
+      }
    }
 
 }


### PR DESCRIPTION
Not closing the InputStream makes this test flaky on Windows. The test
breaks because FileMoveManager::delete(java.io.File) Line 221 fails
to delete the file if it's still "owned" by the JVM process on Windows.

(cherry picked from commit 32fd445dd263250f3afa065059b178d0f352c77b)
(cherry picked from commit 41e79470ad0fd0baa2b12e153221684d02f1f630)