### PR TITLE
 ARTEMIS-2201 Added tests on DEFAULT_JOURNAL_FILE_OPEN_TIMEOUT value

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
@@ -242,6 +242,10 @@ public class JournalFilesRepository {
       return dataFiles.size();
    }
 
+   public int getJournalFileOpenTimeout() {
+      return journalFileOpenTimeout;
+   }
+
    public Collection<JournalFile> getDataFiles() {
       return dataFiles;
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerPolicy;
@@ -668,6 +669,8 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       ActiveMQServerImpl server = new ActiveMQServerImpl();
       try {
          server.start();
+         JournalImpl journal = (JournalImpl) server.getStorageManager().getBindingsJournal();
+         Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultJournalFileOpenTimeout(), journal.getFilesRepository().getJournalFileOpenTimeout());
          Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultJournalFileOpenTimeout(), server.getConfiguration().getJournalFileOpenTimeout());
       } finally {
          server.stop();
@@ -676,12 +679,14 @@ public class FileConfigurationTest extends ConfigurationImplTest {
 
    @Test
    public void testJournalFileOpenTimeoutValue() throws Exception {
-      int timeout = RandomUtil.randomInt();
+      int timeout = RandomUtil.randomPositiveInt();
       Configuration configuration = createConfiguration("shared-store-master-hapolicy-config.xml");
       configuration.setJournalFileOpenTimeout(timeout);
       ActiveMQServerImpl server = new ActiveMQServerImpl(configuration);
       try {
          server.start();
+         JournalImpl journal = (JournalImpl) server.getStorageManager().getBindingsJournal();
+         Assert.assertEquals(timeout, journal.getFilesRepository().getJournalFileOpenTimeout());
          Assert.assertEquals(timeout, server.getConfiguration().getJournalFileOpenTimeout());
       } finally {
          server.stop();


### PR DESCRIPTION
It contains 2 commits:

- (cherry picked from commit 6dfa9a1fa4a22705ed6c3ee9a1c0f20046cbfb0a)
(cherry picked from commit a1f74d86db7003fa64e59a4aace9b7e7de659645)
- (cherry picked from commit a3001fd9bd8456f30ba0ddddc9ba767e32bad7e1)
(cherry picked from commit 0790698ebffeb7a5d4b970b37f880c5cdfb77d10)

downstream: https://issues.jboss.org/browse/ENTMQBR-2195