### PR TITLE
ARTEMIS-2190 core JMS client leaks temp dest names

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -537,6 +537,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    public void removeTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.remove(queueAddress);
+      knownDestinations.remove(queueAddress);
    }
 
    public void addKnownDestination(final SimpleString address) {

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
@@ -27,6 +27,9 @@ import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.naming.NamingException;
 
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
 import org.junit.Test;
 
@@ -119,6 +122,51 @@ public class TemporaryDestinationTest extends JMSTestCase {
          ProxyAssertSupport.assertNotNull(m2);
 
          ProxyAssertSupport.assertEquals(messageText, m2.getText());
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryQueueLeak() throws Exception {
+      ActiveMQConnection conn = null;
+
+      try {
+         conn = (ActiveMQConnection) createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         TemporaryQueue tempQueue = producerSession.createTemporaryQueue();
+
+         MessageProducer producer = producerSession.createProducer(tempQueue);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempQueue);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         tempQueue.delete();
+
+         ProxyAssertSupport.assertFalse(conn.containsKnownDestination(SimpleString.toSimpleString(tempQueue.getQueueName())));
+
+         ProxyAssertSupport.assertFalse(conn.containsTemporaryQueue(SimpleString.toSimpleString(tempQueue.getQueueName())));
       } finally {
          if (conn != null) {
             conn.close();
@@ -254,6 +302,126 @@ public class TemporaryDestinationTest extends JMSTestCase {
          conn.close();
          conn = createConnection("guest", "guest");
          try {
+            producer.send(m);
+            ProxyAssertSupport.fail();
+         } catch (JMSException e) {
+         }
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryQueueDeletedAfterSessionClosed() throws Exception {
+      servers.get(0).getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateAddresses(false).setAutoCreateQueues(false));
+
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Make sure temporary queue cannot be used after it has been deleted
+
+         TemporaryQueue tempQueue = producerSession.createTemporaryQueue();
+
+         MessageProducer producer = producerSession.createProducer(tempQueue);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempQueue);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         consumerSession.close();
+
+         producer.close();
+
+         producerSession.close();
+
+         tempQueue.delete();
+
+         producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         try {
+            producer = producerSession.createProducer(tempQueue);
+            producer.send(m);
+            ProxyAssertSupport.fail();
+         } catch (JMSException e) {
+         }
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryTopicDeletedAfterSessionClosed() throws Exception {
+      servers.get(0).getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateAddresses(false).setAutoCreateQueues(false));
+
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Make sure temporary topic cannot be used after it has been deleted
+
+         TemporaryTopic tempTopic = producerSession.createTemporaryTopic();
+
+         MessageProducer producer = producerSession.createProducer(tempTopic);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempTopic);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         consumerSession.close();
+
+         producer.close();
+
+         producerSession.close();
+
+         tempTopic.delete();
+
+         producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         try {
+            producer = producerSession.createProducer(tempTopic);
             producer.send(m);
             ProxyAssertSupport.fail();
          } catch (JMSException e) {


### PR DESCRIPTION
(cherry picked from commit 4ab7923a84230545b1f9eada0b9e595d5c94dc11)
(cherry picked from commit 496e348599306e60c308bf6008ebdcac2fb9750c)

downstream: https://issues.jboss.org/browse/ENTMQBR-2197