### PR TITLE
ARTEMIS-2189 allow deleting temp dest when session is closed

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -396,14 +396,19 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    public void delete() throws JMSException {
       if (session != null) {
-         if (session.getCoreSession().isClosed()) {
-            // Temporary queues will be deleted when the connection is closed.. nothing to be done then!
-            return;
-         }
-         if (isQueue()) {
-            session.deleteTemporaryQueue(this);
-         } else {
-            session.deleteTemporaryTopic(this);
+         /**
+          * The status of the session used to create the temporary destination is uncertain, but the JMS spec states
+          * that the lifetime of the temporary destination is tied to the connection so even if the originating
+          * session is closed the temporary destination should still be deleted. Therefore, just create a new one
+          * and close it after the temporary destination is deleted. This is necessary because the Core API is
+          * predicated on having a Core ClientSession which is encapsulated by the JMS session implementation.
+          */
+         try (ActiveMQSession sessionToUse = (ActiveMQSession) session.getConnection().createSession()) {
+            if (isQueue()) {
+               sessionToUse.deleteTemporaryQueue(this);
+            } else {
+               sessionToUse.deleteTemporaryTopic(this);
+            }
          }
       }
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -1152,6 +1152,10 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
    }
 
+   public ActiveMQConnection getConnection() {
+      return connection;
+   }
+
    // Protected -----------------------------------------------------
 
    // Private -------------------------------------------------------

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
@@ -27,6 +27,7 @@ import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.naming.NamingException;
 
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
 import org.junit.Test;
 
@@ -253,6 +254,126 @@ public class TemporaryDestinationTest extends JMSTestCase {
          conn.close();
          conn = createConnection("guest", "guest");
          try {
+            producer.send(m);
+            ProxyAssertSupport.fail();
+         } catch (JMSException e) {
+         }
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryQueueDeletedAfterSessionClosed() throws Exception {
+      servers.get(0).getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateAddresses(false).setAutoCreateQueues(false));
+
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Make sure temporary queue cannot be used after it has been deleted
+
+         TemporaryQueue tempQueue = producerSession.createTemporaryQueue();
+
+         MessageProducer producer = producerSession.createProducer(tempQueue);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempQueue);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         consumerSession.close();
+
+         producer.close();
+
+         producerSession.close();
+
+         tempQueue.delete();
+
+         producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         try {
+            producer = producerSession.createProducer(tempQueue);
+            producer.send(m);
+            ProxyAssertSupport.fail();
+         } catch (JMSException e) {
+         }
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryTopicDeletedAfterSessionClosed() throws Exception {
+      servers.get(0).getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateAddresses(false).setAutoCreateQueues(false));
+
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Make sure temporary topic cannot be used after it has been deleted
+
+         TemporaryTopic tempTopic = producerSession.createTemporaryTopic();
+
+         MessageProducer producer = producerSession.createProducer(tempTopic);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempTopic);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         consumerSession.close();
+
+         producer.close();
+
+         producerSession.close();
+
+         tempTopic.delete();
+
+         producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         try {
+            producer = producerSession.createProducer(tempTopic);
             producer.send(m);
             ProxyAssertSupport.fail();
          } catch (JMSException e) {


### PR DESCRIPTION
(cherry picked from commit 8a46c3e)
(cherry picked from commit 9d1c691)
Downstream: ENTMQBR-2177
test: org.apache.activemq.artemis.jms.tests.TemporaryDestinationTest#testTemporaryQueueDeletedAfterSessionClosed,org.apache.activemq.artemis.jms.tests.TemporaryDestinationTest#testTemporaryTopicDeletedAfterSessionClosed
component: Artemis
subcomponent: queuing
level: component
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
