### PR TITLE
ARTEMIS-2162 Remove -XX:+AggressiveOpts to improve JDK 11 compatibility

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
@@ -35,7 +35,6 @@
    <executable>%JAVA_HOME%\bin\java.exe</executable>
    <argument>-Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager}</argument>
    <argument>-XX:+UseParallelGC</argument>
-   <argument>-XX:+AggressiveOpts</argument>
    <argument>-Xms512M</argument>
    <argument>-Xmx1024M</argument>
 

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -31,7 +31,7 @@ ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
 
 
 # Java Opts
-JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx2G -Dhawtio.realm=activemq  -Dhawtio.offline="true" -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml"
+JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -Xms512M -Xmx2G -Dhawtio.realm=activemq  -Dhawtio.offline="true" -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml"
 
 #
 # Logs Safepoints JVM pauses: Uncomment to enable them

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -32,7 +32,7 @@ rem Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be 
 rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446
 
 rem Java Opts
-set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
+set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
 
 rem Logs Safepoints JVM pauses: Uncomment to enable them
 rem In addition to the traditional GC logs you could enable some JVM flags to know any meaningful and "hidden" pause that could

--- a/artemis-distribution/src/main/resources/bin/artemis
+++ b/artemis-distribution/src/main/resources/bin/artemis
@@ -45,7 +45,7 @@ if [ -z "$ARTEMIS_HOME" ] ; then
 fi
 
 # Set Defaults Properties
-JAVA_ARGS="-XX:+UseParallelGC -XX:+AggressiveOpts -Xms512M -Xmx1024M"
+JAVA_ARGS="-XX:+UseParallelGC -Xms512M -Xmx1024M"
 CLASSPATH="$ARTEMIS_HOME/lib/artemis-boot.jar"
 
 # OS specific support.

--- a/artemis-distribution/src/main/resources/bin/artemis.cmd
+++ b/artemis-distribution/src/main/resources/bin/artemis.cmd
@@ -45,7 +45,7 @@ echo.
 :RUN_JAVA
 
 rem "Set Defaults."
-set JAVA_ARGS=-XX:+UseParallelGC -XX:+AggressiveOpts -Xms512M -Xmx1024M
+set JAVA_ARGS=-XX:+UseParallelGC -Xms512M -Xmx1024M
 
 rem "Create full JVM Args"
 set JVM_ARGS=%JAVA_ARGS%

--- a/docs/user-manual/en/perf-tuning.md
+++ b/docs/user-manual/en/perf-tuning.md
@@ -205,14 +205,7 @@ from other providers (e.g. IBM or JRockit)
   heap size (`-Xmx`) for the JVM is set at least to 5 x the `global-max-size` of
   the broker.  As an example, in a situation where the broker is under high load
   and running with a `global-max-size` of 1GB, it is recommended the the max heap
-  size is set to 5GB.  
-
-- Aggressive options. Different JVMs provide different sets of JVM tuning
-  parameters, for the Sun Hotspot JVM the full list of options is available
-  [here](http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html).
-  We recommend at least using `-XX:+AggressiveOpts`.  You may get some mileage
-  with the other tuning parameters depending on your OS platform and application
-  usage patterns.
+  size is set to 5GB.
 
 ## Avoiding Anti-Patterns
 

--- a/examples/common/config/server.properties
+++ b/examples/common/config/server.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-server.args=-XX:+UseParallelGC -Xms256M -Xmx256M -XX:+AggressiveOpts -Dcom.sun.management.jmxremote -Djava.util.logging.config.file=${imported.basedir}/config/logging.properties -Djava.naming.factory.initial=org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory
+server.args=-XX:+UseParallelGC -Xms256M -Xmx256M -Dcom.sun.management.jmxremote -Djava.util.logging.config.file=${imported.basedir}/config/logging.properties -Djava.naming.factory.initial=org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory


### PR DESCRIPTION
(cherry picked from commit cfd520e38c3088f9b2a355a5022ae10c4bf8323f)
(cherry picked from commit 297441a8537076872257a2f884c3e14174c60273)

downstream: https://issues.jboss.org/browse/ENTMQBR-2226