### PR TITLE
ARTEMIS-2248 don't create sslEngine w/sniHost in NettyConnector

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -634,8 +634,8 @@ public class NettyConnector extends AbstractConnector {
       SSLEngine engine = Subject.doAs(subject, new PrivilegedExceptionAction<SSLEngine>() {
          @Override
          public SSLEngine run() {
-            if (verifyHost) {
-               return context.createSSLEngine(sniHost != null ? sniHost : host, port);
+            if (host != null && port != -1) {
+               return context.createSSLEngine(host, port);
             } else {
                return context.createSSLEngine();
             }
@@ -665,8 +665,8 @@ public class NettyConnector extends AbstractConnector {
       SSLEngine engine = Subject.doAs(subject, new PrivilegedExceptionAction<SSLEngine>() {
          @Override
          public SSLEngine run() {
-            if (verifyHost) {
-               return context.newEngine(alloc, sniHost != null ? sniHost : host, port);
+            if (host != null && port != -1) {
+               return context.newEngine(alloc, host, port);
             } else {
                return context.newEngine(alloc);
             }


### PR DESCRIPTION
(cherry picked from commit 98ca5833130788326518288289cb12037a784055)
(cherry picked from commit 3c0c91df8dcd37b05046004e5fa433cd44e23749)

downstream ENTMQBR-2294