### PR TITLE
ARTEMIS-2283 Bad WARN message "AMQ222211: Storage is back to stable now"

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.core.paging.impl;
 
 import java.nio.file.FileStore;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -180,13 +179,7 @@ public final class PagingManagerImpl implements PagingManager {
                memoryReleased();
             }
          }
-         Iterator<PagingStore> storeIterator = blockedStored.iterator();
-         while (storeIterator.hasNext()) {
-            PagingStore store = storeIterator.next();
-            if (store.checkReleasedMemory()) {
-               storeIterator.remove();
-            }
-         }
+         blockedStored.removeIf(PagingStore::checkReleasedMemory);
       }
    }
 
@@ -213,9 +206,12 @@ public final class PagingManagerImpl implements PagingManager {
 
       @Override
       public void under(FileStore store, double usage) {
+         final boolean diskFull = PagingManagerImpl.this.diskFull;
          if (diskFull || !blockedStored.isEmpty() || !memoryCallback.isEmpty()) {
-            ActiveMQServerLogger.LOGGER.diskCapacityRestored();
-            diskFull = false;
+            if (diskFull) {
+               ActiveMQServerLogger.LOGGER.diskCapacityRestored();
+               PagingManagerImpl.this.diskFull = false;
+            }
             checkMemoryRelease();
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1337,7 +1337,7 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void diskBeyondCapacity();
 
-   @LogMessage(level = Logger.Level.WARN)
+   @LogMessage(level = Logger.Level.INFO)
    @Message(id = 222211, value = "Storage is back to stable now, under max-disk-usage.",
       format = Message.Format.MESSAGE_FORMAT)
    void diskCapacityRestored();


### PR DESCRIPTION
LocalMonitor::under on PagingManagerImpl won't log anymore with a
warning message if the producers got unblocked and with info
if disk it getting freed

(cherry picked from commit ac4cd4856c386c4cd824a56b68c6c34a2a1aab6c)

https://issues.jboss.org/browse/ENTMQBR-2095