### PR TITLE
ARTEMIS-2300 Expiry notifications are not called from scanner

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/TransactionPropertyIndexes.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/TransactionPropertyIndexes.java
@@ -33,4 +33,6 @@ public class TransactionPropertyIndexes {
    public static final int PAGE_DELIVERY = 7;
 
    public static final int PAGE_CURSOR_POSITIONS = 8;
+
+   public static final int EXPIRY_LOGGER = 9;
 }


### PR DESCRIPTION
(cherry picked from commit b8b7cc8)
downstream: ENTMQBR-2420

test: org.apache.activemq.artemis.tests.integration.management.NotificationTest#testMessageExpiredWithoutConsumers,org.apache.activemq.artemis.tests.integration.management.NotificationTest#testMessageExpired
component: Artemis
subcomponent: management
level: integration
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
