### PR TITLE
ARTEMIS-2299 Support for redelivery-delay and LVQ

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -119,6 +119,10 @@ public class LastValueQueue extends QueueImpl {
 
    @Override
    public synchronized void addHead(final MessageReference ref, boolean scheduling) {
+      // we first need to check redelivery-delay, as we can't put anything on headers if redelivery-delay
+      if (!scheduling && scheduledDeliveryHandler.checkAndSchedule(ref, false)) {
+         return;
+      }
 
       SimpleString lastValueProp = ref.getLastValueProperty();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -186,7 +186,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    private final QueuePendingMessageMetrics deliveringMetrics = new QueuePendingMessageMetrics(this);
 
-   private final ScheduledDeliveryHandler scheduledDeliveryHandler;
+   protected final ScheduledDeliveryHandler scheduledDeliveryHandler;
 
    private AtomicLong messagesAdded = new AtomicLong(0);
 


### PR DESCRIPTION
(cherry picked from commit 9e45a4a)
downstream: ENTMQBR-2421
test: org.apache.activemq.artemis.tests.integration.server.LVQTest#testMultipleRollback
component: Artemis
subcomponent: message_delivery
level: integration
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
