### PR TITLE
ARTEMIS-2294 dupe detection for AMQP same as core

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -971,7 +971,7 @@ public class AMQPMessage extends RefCountMessage {
 
    @Override
    public Object getDuplicateProperty() {
-      return null;
+      return getObjectProperty(org.apache.activemq.artemis.api.core.Message.HDR_DUPLICATE_DETECTION_ID);
    }
 
    @Override


### PR DESCRIPTION
(cherry picked from commit 2dd0671)
downstream: ENTMQBR-2414

test: org.apache.activemq.artemis.tests.integration.amqp.AmqpSenderTest#testDuplicateDetection,org.apache.activemq.artemis.tests.integration.amqp.JMSMessageProducerTest#testDuplicateDetection
component: amqp
subcomponent: message_delivery
level: integration
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
