### PR TITLE
ARTEMIS-2329 AddressSettings inconsistence on decoding

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -1070,7 +1070,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableBoolean(defaultGroupRebalance) +
          BufferHelper.sizeOfNullableInteger(defaultGroupBuckets) +
          BufferHelper.sizeOfNullableLong(autoDeleteQueuesMessageCount) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteQueues);
+         BufferHelper.sizeOfNullableBoolean(autoDeleteCreatedQueues);
    }
 
    @Override


### PR DESCRIPTION
This is fixing these tests:
- org.apache.activemq.artemis.tests.integration.paging.PagingOrderTest#testPagingOverCreatedDestinationQueues
- org.apache.activemq.artemis.tests.integration.paging.PagingOrderTest#testPagingOverCreatedDestinationTopics

No additional tests are needed as this change is covereted by the current testsuite

(cherry picked from commit 9ec9e0785b9a54de26099bb32416010cdf30295c)

downstream: ENTMQBR-2492