### PR TITLE
ARTEMIS-2309 TempQueueCleanerUpper instances are leaking

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -396,18 +396,30 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    public void delete() throws JMSException {
       if (session != null) {
-         /**
-          * The status of the session used to create the temporary destination is uncertain, but the JMS spec states
-          * that the lifetime of the temporary destination is tied to the connection so even if the originating
-          * session is closed the temporary destination should still be deleted. Therefore, just create a new one
-          * and close it after the temporary destination is deleted. This is necessary because the Core API is
-          * predicated on having a Core ClientSession which is encapsulated by the JMS session implementation.
-          */
-         try (ActiveMQSession sessionToUse = (ActiveMQSession) session.getConnection().createSession()) {
+         boolean openedHere = false;
+         ActiveMQSession sessionToUse = session;
+
+         if (session.getCoreSession().isClosed()) {
+            sessionToUse = (ActiveMQSession)session.getConnection().createSession();
+            openedHere = true;
+         }
+
+         try {
+            /**
+             * The status of the session used to create the temporary destination is uncertain, but the JMS spec states
+             * that the lifetime of the temporary destination is tied to the connection so even if the originating
+             * session is closed the temporary destination should still be deleted. Therefore, just create a new one
+             * and close it after the temporary destination is deleted. This is necessary because the Core API is
+             * predicated on having a Core ClientSession which is encapsulated by the JMS session implementation.
+             */
             if (isQueue()) {
                sessionToUse.deleteTemporaryQueue(this);
             } else {
                sessionToUse.deleteTemporaryTopic(this);
+            }
+         } finally {
+            if (openedHere) {
+               sessionToUse.close();
             }
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -280,6 +280,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       this.closeables.add(closeable);
    }
 
+   public Map<SimpleString, TempQueueCleanerUpper> getTempQueueCleanUppers() {
+      return tempQueueCleannerUppers;
+   }
+
    @Override
    public void disableSecurity() {
       this.securityEnabled = false;


### PR DESCRIPTION
The changes from ARTEMIS-2189 mean that
o.a.a.a.c.s.i.ServerSessionImpl#deleteQueue
is no longer called from the same ServerSessionImpl instance that
created it which means that TempQueueCleanerUpper instances will leak.
To resolve the leak the client will only create a new session when
necessary instead of every time delete() is invoked.

(cherry picked from commit e0a7073884c10d0038d28005308b16760dbe3563)

downstream: ENTMQBR-2451
(cherry picked from commit 7f86278d4c4d12ecf3335a7365ed60c5865bfad1)

issue: https://issues.jboss.org/browse/JBEAP-16769
upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-2309
upstream PR: https://github.com/apache/activemq-artemis/pull/2623 