### PR TITLE
ARTEMIS-2359 Upgrade to Guava 24.1

### DIFF
--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -67,6 +67,12 @@
       <version>${hawtio.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <!-- License: Apache 2.0 -->
+    </dependency>
   </dependencies>
 
   <build>
@@ -110,6 +116,7 @@
                 <exclude>bower_components/jquery/src/**/*</exclude>
                 <exclude>bower_components/jquery/test/**/*</exclude>
                 <exclude>bower_components/js-logger/src/**/*</exclude>
+                <excluse>WEB-INF/lib/guava*.jar</excluse>
                 <excluse>WEB-INF/lib/slf4j-api*.jar</excluse>
                 <excluse>lib/camelModel.js</excluse>
                 <exclude>app/activemq/**/*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <commons.collections.version>3.2.2</commons.collections.version>
       <commons.text.version>1.6</commons.text.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>
-      <guava.version>20.0</guava.version>
+      <guava.version>24.1-jre</guava.version>
       <jaxb.version>2.2.28</jaxb.version>
       <jboss.logging.version>3.4.0.Final</jboss.logging.version>
       <jetty.version>9.4.3.v20170317</jetty.version>
@@ -108,7 +108,7 @@
       <jb.logmanager.version>2.1.10.Final</jb.logmanager.version>
       <jb.slf4j-jboss-logmanager.version>1.0.4.GA</jb.slf4j-jboss-logmanager.version>
        <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>
-      <airlift.version>0.7</airlift.version>
+      <airlift.version>0.8</airlift.version>
       <geronimo.annotation.1.1.spec.version>1.0.1</geronimo.annotation.1.1.spec.version>
       <geronimo.ejb.3.0.spec.version>1.0.1</geronimo.ejb.3.0.spec.version>
       <geronimo.jta.1.1.spec.version>1.1.1</geronimo.jta.1.1.spec.version>
@@ -826,6 +826,12 @@
             <artifactId>osgi.cmpn</artifactId>
             <version>6.0.0</version>
             <scope>provided</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
       </dependencies>


### PR DESCRIPTION
CVE-2018-10237 guava: Unbounded memory allocation in AtomicDoubleArray
and CompoundOrdering classes allow remote attackers to cause a denial
of service.

(cherry picked from commit d708be31896907e06c8790d1bc9a34abae21cdc7)