### PR TITLE
ARTEMIS-2354 Improve compatibillity of tests with JDK 11

### DIFF
--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -29,6 +29,7 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
+      <javax.annotation.version>1.3.2</javax.annotation.version>
    </properties>
 
    <artifactId>artemis-cdi-client</artifactId>
@@ -82,6 +83,11 @@
       <dependency>
          <groupId>javax.inject</groupId>
          <artifactId>javax.inject</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>javax.annotation</groupId>
+         <artifactId>javax.annotation-api</artifactId>
+         <version>${javax.annotation.version}</version>
       </dependency>
       <dependency>
          <groupId>javax.enterprise</groupId>

--- a/artemis-rest/pom.xml
+++ b/artemis-rest/pom.xml
@@ -129,6 +129,12 @@
          <version>${version.jaxb-api}</version>
       </dependency>
       <dependency>
+         <groupId>org.glassfish.jaxb</groupId>
+         <artifactId>jaxb-runtime</artifactId>
+         <version>2.3.2</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
          <version>2.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <jetty.version>9.4.3.v20170317</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
-      <mockito.version>2.8.47</mockito.version>
+      <mockito.version>2.25.0</mockito.version>
       <netty.version>4.1.32.Final</netty.version>
       <commons.io.version>2.6</commons.io.version>
       <netty-tcnative-version>2.0.22.Final</netty-tcnative-version>


### PR DESCRIPTION
It contains 2 commits merged into one (for simplicity):

(cherry picked from f8d3a8f2f2e81f80189d2ab4149a6228e70d3425)
(cherry picked from 417ee543fd22d889df28795c8eba4ed69ed91464)

downstream: ENTMQBR-1932