### PR TITLE
ARTEMIS-2378 respect openwire removeInfo lastSequenceId when dealing with delivery count

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JMSConsumer2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JMSConsumer2Test.java
@@ -148,6 +148,7 @@ public class JMSConsumer2Test extends BasicOpenWireTest {
       m = consumer.receive(5000);
       System.out.println("m2 received: " + m);
       assertNotNull(m);
+      assertFalse("redelivered flag set", m.getJMSRedelivered());
 
       // install another consumer while message dispatch is unacked/uncommitted
       Session redispatchSession = connection.createSession(true, Session.SESSION_TRANSACTED);


### PR DESCRIPTION
(cherry picked from commit d1add00)
downstream: ENTMQBR-2470
test: org.apache.activemq.artemis.tests.integration.openwire.amq.JMSConsumer2Test#testRedispatchOfUncommittedTx,org.apache.activemq.artemis.tests.integration.openwire.amq.RedeliveryPolicyTest#verifyNoRedeliveryFlagAfterCloseNoReceive
component: Artemis
subcomponent: protocols
level: integration
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
