### PR TITLE
ARTEMIS-2439 ServerSessionImpl leaks addr names

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1039,6 +1039,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
          remotingConnection.removeFailureListener(cleaner);
       }
+
+      if (server.getAddressInfo(unPrefixedQueueName) == null) {
+         targetAddressInfos.remove(queueToDelete);
+      }
    }
 
    @Override
@@ -1876,7 +1880,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       connectionFailed(me, failedOver);
    }
 
-   private Map<SimpleString, Pair<Object, AtomicLong>> cloneTargetAddresses() {
+   public Map<SimpleString, Pair<Object, AtomicLong>> cloneTargetAddresses() {
       return new HashMap<>(targetAddressInfos);
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TemporaryDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TemporaryDestinationTest.java
@@ -228,6 +228,25 @@ public class TemporaryDestinationTest extends JMSTestBase {
    }
 
    @Test
+   public void testForTempQueueTargetInfosLeak() throws Exception {
+      try {
+         conn = createConnection();
+         Session s = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         TemporaryQueue temporaryQueue = s.createTemporaryQueue();
+         MessageProducer producer = s.createProducer(temporaryQueue);
+         producer.send(s.createMessage());
+         temporaryQueue.delete();
+         for (ServerSession serverSession : server.getSessions()) {
+            assertFalse(((ServerSessionImpl)serverSession).cloneTargetAddresses().containsKey(SimpleString.toSimpleString(temporaryQueue.getQueueName())));
+         }
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
    public void testForSecurityCacheLeak() throws Exception {
       server.getSecurityStore().setSecurityEnabled(true);
       ActiveMQJAASSecurityManager securityManager = (ActiveMQJAASSecurityManager) server.getSecurityManager();


### PR DESCRIPTION
Downstream: https://issues.jboss.org/browse/ENTMQBR-2711
Upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-2439
Upstream PR: apache/activemq-artemis#2780
(cherry picked from commit 3a68288)
test: org.apache.activemq.artemis.tests.integration.jms.client.TemporaryDestinationTest#testForTempQueueTargetInfosLeak
            component: jms-client
            subcomponent: queuing
            level: integration
            importance: high
            type: functional
            subtype: compliance
            verifies: AMQ-90
            