### PR TITLE
ARTEMIS-2454 Message Body damaged after re-encoding

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.utils;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Arrays;
@@ -62,7 +64,7 @@ public class ByteUtil {
       StringBuffer buffer = new StringBuffer();
 
       int line = 1;
-      buffer.append("/*  1 */ \"");
+      buffer.append("/*  0 */ \"");
       for (int i = 0; i < str.length(); i += groupSize) {
          buffer.append(str.substring(i, i + Math.min(str.length() - i, groupSize)));
 
@@ -72,7 +74,7 @@ public class ByteUtil {
             if (line < 10) {
                buffer.append(" ");
             }
-            buffer.append(Integer.toString(line) + " */ \"");
+            buffer.append(Integer.toString(i) + " */ \"");
          } else if ((i + groupSize) % groupSize == 0 && str.length() - i > groupSize) {
             buffer.append("\" + \"");
          }
@@ -99,6 +101,30 @@ public class ByteUtil {
          hexChars[j * 2] = hexArray[v >>> 4];
          hexChars[j * 2 + 1] = hexArray[v & 0x0F];
       }
+      return new String(hexChars);
+   }
+
+   /** Simplify reading of a byte array in a programmers understable way */
+   public static String debugByteArray(byte[] byteArray) {
+      StringWriter builder = new StringWriter();
+      PrintWriter writer = new PrintWriter(builder);
+      for (int i = 0; i < byteArray.length; i++) {
+         writer.print("\t[" + i + "]=" + ByteUtil.byteToChar(byteArray[i]) + " / " + byteArray[i]);
+         if (i > 0 && i % 8 == 0) {
+            writer.println();
+         } else {
+            writer.print(" ");
+         }
+      }
+      return builder.toString();
+   }
+
+
+   public static String byteToChar(byte value) {
+      char[] hexChars = new char[2];
+      int v = value & 0xFF;
+      hexChars[0] = hexArray[v >>> 4];
+      hexChars[1] = hexArray[v & 0x0F];
       return new String(hexChars);
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -41,6 +41,7 @@ import org.apache.activemq.artemis.protocol.amqp.util.NettyReadable;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
 import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
 import org.apache.activemq.artemis.reader.MessageUtil;
+import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.apache.qpid.proton.amqp.Binary;
@@ -293,6 +294,12 @@ public class AMQPMessage extends RefCountMessage {
       ensureMessageDataScanned();
       ensureDataIsValid();
       return scanForMessageSection(applicationPropertiesPosition, ApplicationProperties.class);
+   }
+
+   /** This is different from toString, as this will print an expanded version of the buffer
+    *  in Hex and programmers's readable format */
+   public String toDebugString() {
+      return ByteUtil.debugByteArray(data.array());
    }
 
    /**

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadable.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadable.java
@@ -151,7 +151,7 @@ public class NettyReadable implements ReadableBuffer {
 
    @Override
    public int arrayOffset() {
-      return buffer.arrayOffset() + buffer.readerIndex();
+      return buffer.arrayOffset();
    }
 
    @Override


### PR DESCRIPTION
(cherry picked from commit 5f75f68)
downstream: ENTMQBR-2741

test: org.apache.activemq.artemis.protocol.amqp.converter.TestConversions#testEditAndConvert,org.apache.activemq.artemis.protocol.amqp.converter.TestConversions#testExpandPropertiesAndConvert
component: amqp
subcomponent: protocols
level: component
importance: medium
type: functional
subtype: interoperability
verifies: AMQ-90
