### PR TITLE
ARTEMIS-2454 Fixing body re-encoding

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -208,8 +208,10 @@ public class AMQPMessage extends RefCountMessage {
     * @return a MessageImpl that wraps the AMQP message data in this {@link AMQPMessage}
     */
    public MessageImpl getProtonMessage() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      if (data == null) {
+         throw new NullPointerException("Data is not initialized");
+      }
+      ensureScanning();
 
       MessageImpl protonMessage = null;
       if (data != null) {
@@ -228,9 +230,13 @@ public class AMQPMessage extends RefCountMessage {
     * @return a copy of the Message Header if one exists or null if none present.
     */
    public Header getHeader() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(headerPosition, Header.class);
+   }
+
+   private void ensureScanning() {
+      ensureDataIsValid();
+      ensureMessageDataScanned();
    }
 
    /**
@@ -240,8 +246,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return a copy of the {@link DeliveryAnnotations} present in the message or null if non present.
     */
    public DeliveryAnnotations getDeliveryAnnotations() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(deliveryAnnotationsPosition, DeliveryAnnotations.class);
    }
 
@@ -267,8 +272,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return a copy of the {@link MessageAnnotations} present in the message or null if non present.
     */
    public MessageAnnotations getMessageAnnotations() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(messageAnnotationsPosition, MessageAnnotations.class);
    }
 
@@ -279,8 +283,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return a copy of the Message Properties if one exists or null if none present.
     */
    public Properties getProperties() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(propertiesPosition, Properties.class);
    }
 
@@ -291,8 +294,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return a copy of the {@link ApplicationProperties} present in the message or null if non present.
     */
    public ApplicationProperties getApplicationProperties() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(applicationPropertiesPosition, ApplicationProperties.class);
    }
 
@@ -310,8 +312,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return the Section that makes up the body of this message.
     */
    public Section getBody() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
 
       // We only handle Sections of AmqpSequence, AmqpValue and Data types so we filter on those.
       // There could also be a Footer and no body so this will prevent a faulty return type in case
@@ -327,8 +328,7 @@ public class AMQPMessage extends RefCountMessage {
     * @return the Footer that was encoded into this AMQP Message.
     */
    public Footer getFooter() {
-      ensureMessageDataScanned();
-      ensureDataIsValid();
+      ensureScanning();
       return scanForMessageSection(Math.max(0, remainingBodyPosition), Footer.class);
    }
 
@@ -445,11 +445,11 @@ public class AMQPMessage extends RefCountMessage {
    private synchronized void ensureMessageDataScanned() {
       if (!messageDataScanned) {
          scanMessageData();
-         messageDataScanned = true;
       }
    }
 
    private synchronized void scanMessageData() {
+      this.messageDataScanned = true;
       DecoderImpl decoder = TLSEncode.getDecoder();
       decoder.setBuffer(data.rewind());
 
@@ -781,21 +781,17 @@ public class AMQPMessage extends RefCountMessage {
 
       encodeMessage();
       scanMessageData();
-
-      messageDataScanned = true;
-      modified = false;
    }
 
    private synchronized void ensureDataIsValid() {
-      assert data != null;
-
       if (modified) {
          encodeMessage();
-         modified = false;
       }
    }
 
    private synchronized void encodeMessage() {
+      this.modified = false;
+      this.messageDataScanned = false;
       int estimated = Math.max(1500, data != null ? data.capacity() + 1000 : 0);
       ByteBuf buffer = PooledByteBufAllocator.DEFAULT.heapBuffer(estimated);
       EncoderImpl encoder = TLSEncode.getEncoder();
@@ -1542,14 +1538,15 @@ public class AMQPMessage extends RefCountMessage {
 
    @Override
    public String toString() {
-      return "AMQPMessage [durable=" + isDurable() +
+      /* return "AMQPMessage [durable=" + isDurable() +
          ", messageID=" + getMessageID() +
          ", address=" + getAddress() +
          ", size=" + getEncodeSize() +
          ", applicationProperties=" + applicationProperties +
          ", properties=" + properties +
          ", extraProperties = " + getExtraProperties() +
-         "]";
+         "]"; */
+      return super.toString();
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
@@ -287,11 +287,11 @@ public class TestConversions extends Assert {
       encodedMessage.setAddress(SimpleString.toSimpleString("xxxx.v1.queue"));
 
       for (int i = 0; i < 100; i++) {
-         encodedMessage.getApplicationProperties().getValue().put("another" + i, "value" + i);
+         encodedMessage.putStringProperty("another" + i, "value" + i);
          encodedMessage.messageChanged();
          encodedMessage.reencode();
-         AmqpValue value = (AmqpValue)encodedMessage.getProtonMessage().getBody();
-         Assert.assertEquals(text, (String)value.getValue());
+         AmqpValue value = (AmqpValue) encodedMessage.getProtonMessage().getBody();
+         Assert.assertEquals(text, (String) value.getValue());
          ICoreMessage coreMessage = encodedMessage.toCore();
          if (logger.isDebugEnabled()) {
             logger.debug("Converted message: " + coreMessage);
@@ -311,7 +311,43 @@ public class TestConversions extends Assert {
             encodedMessage = encodeAndCreateAMQPMessage(message);
 
          }
+      }
+   }
 
+   @Test
+   public void testExpandNoReencode() throws Exception {
+
+      Map<String, Object> mapprop = createPropertiesMap();
+      ApplicationProperties properties = new ApplicationProperties(mapprop);
+      properties.getValue().put("hello", "hello");
+      MessageImpl message = (MessageImpl) Message.Factory.create();
+      MessageAnnotations annotations = new MessageAnnotations(new HashMap<>());
+      message.setMessageAnnotations(annotations);
+      message.setApplicationProperties(properties);
+
+      String text = "someText";
+      message.setBody(new AmqpValue(text));
+
+      AMQPMessage encodedMessage = encodeAndCreateAMQPMessage(message);
+      TypedProperties extraProperties = new TypedProperties();
+      encodedMessage.setAddress(SimpleString.toSimpleString("xxxx.v1.queue"));
+
+      for (int i = 0; i < 100; i++) {
+         encodedMessage.setMessageID(333L);
+         if (i % 3 == 0) {
+            encodedMessage.referenceOriginalMessage(encodedMessage, "SOME-OTHER-QUEUE-DOES-NOT-MATTER-WHAT");
+         } else {
+            encodedMessage.referenceOriginalMessage(encodedMessage, "XXX");
+         }
+         encodedMessage.putStringProperty("another " + i, "value " + i);
+         encodedMessage.messageChanged();
+         if (i % 2 == 0) {
+            encodedMessage.setAddress("THIS-IS-A-BIG-THIS-IS-A-BIG-ADDRESS-THIS-IS-A-BIG-ADDRESS-RIGHT");
+         } else {
+            encodedMessage.setAddress("A"); // small address
+         }
+         encodedMessage.messageChanged();
+         ICoreMessage coreMessage = encodedMessage.toCore();
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
@@ -106,8 +106,6 @@ public class DivertImpl implements Divert {
 
          copy.setExpiration(message.getExpiration());
 
-         copy.reencode();
-
          switch (routingType) {
             case ANYCAST:
                copy.setRoutingType(RoutingType.ANYCAST);
@@ -126,7 +124,8 @@ public class DivertImpl implements Divert {
             copy = transformer.transform(copy);
          }
 
-         copy.messageChanged();
+         // We call reencode at the end only, in a single call.
+         copy.reencode();
       } else {
          copy = message;
       }


### PR DESCRIPTION
(cherry picked from commit c929d34)
downstream: ENTMQBR-2741

test: org.apache.activemq.artemis.protocol.amqp.converter.TestConversions#testExpandPropertiesAndConvert,org.apache.activemq.artemis.protocol.amqp.converter.TestConversions#testExpandNoReencode,org.apache.activemq.artemis.tests.integration.divert.DivertTest#testCrossProtocol
component: amqp
subcomponent: protocols
level: component
importance: medium
type: functional
subtype: interoperability
verifies: AMQ-90
