### PR TITLE
ARTEMIS-2473 RemoteQueueBindingImpl should check for empty filters

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/RemoteQueueBindingImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/RemoteQueueBindingImpl.java
@@ -162,6 +162,7 @@ public class RemoteQueueBindingImpl implements RemoteQueueBinding {
          return true;
       } else {
          for (Filter filter : filters) {
+            assert filter != null : "filters contains a null filter";
             if (filter.match(message)) {
                return true;
             }
@@ -203,7 +204,7 @@ public class RemoteQueueBindingImpl implements RemoteQueueBinding {
 
    @Override
    public synchronized void addConsumer(final SimpleString filterString) throws Exception {
-      if (filterString != null) {
+      if (filterString != null && !filterString.isEmpty()) {
          // There can actually be many consumers on the same queue with the same filter, so we need to maintain a ref
          // count
 
@@ -223,7 +224,7 @@ public class RemoteQueueBindingImpl implements RemoteQueueBinding {
 
    @Override
    public synchronized void removeConsumer(final SimpleString filterString) throws Exception {
-      if (filterString != null) {
+      if (filterString != null && !filterString.isEmpty()) {
          Integer i = filterCounts.get(filterString);
 
          if (i != null) {


### PR DESCRIPTION
(cherry picked from commit 9413925)
downstream: ENTMQBR-1464
test: org.apache.activemq.artemis.tests.unit.core.server.cluster.impl.RemoteQueueBindImplTest#testAddRemoveConsumer,org.apache.activemq.artemis.tests.unit.core.server.cluster.impl.RemoteQueueBindImplTest#testAddRemoveConsumerUsingSameFilter,org.apache.activemq.artemis.tests.unit.core.server.cluster.impl.RemoteQueueBindImplTest#testAddRemoveConsumerUsingEmptyFilters,org.apache.activemq.artemis.tests.unit.core.server.cluster.impl.RemoteQueueBindImplTest#testAddRemoveConsumerUsingNullFilters
component: Artemis
subcomponent: clustering
level: component
importance: medium
type: functional
subtype: compliance
verifies: AMQ-90
