### PR TITLE
ARTEMIS-2470 Updated Apache BeanUtils to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <commons.logging.version>1.2</commons.logging.version>
       <activemq5-version>5.11.0.redhat-630377</activemq5-version>
       <apache.derby.version>10.11.1.1</apache.derby.version>
-      <commons.beanutils.version>1.9.3</commons.beanutils.version>
+      <commons.beanutils.version>1.9.4</commons.beanutils.version>
       <commons.collections.version>3.2.2</commons.collections.version>
       <commons.text.version>1.6</commons.text.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>


### PR DESCRIPTION
1.9.4 is a minor update do address CVE-2014-0114:
http://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.4/RELEASE-NOTES.txt

(cherry picked from commit 39fe4fd9efb3fb0230cb24c1ef7b52fd819758f9)

downstream: ENTMQBR-2849