### PR TITLE
ARTEMIS-2493 OpenWire session close doesn't cleanup consumer refs

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -1177,16 +1177,15 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
          // Don't let new consumers or producers get added while we are closing
          // this down.
          session.shutdown();
-         // Cascade the connection stop producers.
-         // we don't stop consumer because in core
-         // closing the session will do the job
+
          for (ProducerId producerId : session.getProducerIds()) {
-            try {
-               processRemoveProducer(producerId);
-            } catch (Throwable e) {
-               // LOG.warn("Failed to remove producer: {}", producerId, e);
-            }
+            processRemoveProducer(producerId);
          }
+
+         for (ConsumerId consumerId : session.getConsumerIds()) {
+            processRemoveConsumer(consumerId, lastDeliveredSequenceId);
+         }
+
          state.removeSession(id);
          propagateLastSequenceId(session, lastDeliveredSequenceId);
          removeSession(context, session.getInfo());

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -682,4 +682,8 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       }
       return mappedDestination;
    }
+
+   public List<OpenWireConnection> getConnections() {
+      return connections;
+   }
 }


### PR DESCRIPTION
When an openwire client closes the session, the broker doesn't
clean up its server consumer references even though the core
consumers are closed. This results a leak when sessions within
a connection are created and closed when the connection keeps open.

downstream: https://issues.jboss.org/browse/ENTMQBR-2876