### PR TITLE
ARTEMIS-2597 Memory Leak when closing AMQP Consumers in the context

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -558,6 +558,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
    public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
       try {
          closed = true;
+         protonSession.removeSender(sender);
          sessionSPI.closeSender(brokerConsumer);
          // if this is a link close rather than a connection close or detach, we need to delete
          // any durable resources for say pub subs
@@ -898,5 +899,9 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       connection.requireInHandler();
       sender.drained();
       connection.flush();
+   }
+
+   public AMQPSessionContext getSessionContext() {
+      return protonSession;
    }
 }


### PR DESCRIPTION
Remove server senders on remote link close.
(cherry picked from commit 1716655)
downstream: ENTMQBR-3163
test: org.apache.activemq.artemis.tests.integration.client.ConsumerTest#testContextOnConsumerAMQP
            component: amqp
            subcomponent: protocols
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            