### PR TITLE
ARTEMIS-2597 Memory Leak when closing AMQP Consumers in the context

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -554,6 +554,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
    public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
       try {
          closed = true;
+         protonSession.removeSender(sender);
          sessionSPI.closeSender(brokerConsumer);
          // if this is a link close rather than a connection close or detach, we need to delete
          // any durable resources for say pub subs
@@ -889,5 +890,9 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       connection.requireInHandler();
       sender.drained();
       connection.flush();
+   }
+
+   public AMQPSessionContext getSessionContext() {
+      return protonSession;
    }
 }


### PR DESCRIPTION
Remove server senders on remote link close.

(cherry picked from commit 1716655214f1605cf392f1be8862c7ff61785f64)

downstream: ENTMQBR-3227