### PR TITLE
ARTEMIS-2792 Fix default network pinger command for linux

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.logs.ActiveMQUtilLogger;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
+import org.apache.activemq.artemis.utils.Env;
 import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
 import org.jboss.logging.Logger;
 
@@ -51,7 +52,7 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    public static final String IPV6_DEFAULT_COMMAND = "ping6 -c 1 %2$s";
 
-   public static final String IPV4_DEFAULT_COMMAND = "ping -c 1 -t %d %s";
+   public static final String IPV4_DEFAULT_COMMAND = Env.isMacOs() ? "ping -c 1 -t %d %s" : "ping -c 1 -w %d %s";
 
    private String ipv4Command = IPV4_DEFAULT_COMMAND;
 

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
@@ -326,4 +326,14 @@ public class NetworkHealthTest {
       Assert.assertEquals(0, purePing.get());
    }
 
+   @Test(timeout = 30_000)
+   public void testPurePingTimeout() throws Exception {
+      NetworkHealthCheck check = new NetworkHealthCheck(null, 100, 2000);
+
+      long time = System.currentTimeMillis();
+      //[RFC1166] reserves the address block 192.0.2.0/24 for test.
+      Assert.assertFalse(check.purePing(InetAddress.getByName("192.0.2.0")));
+      Assert.assertTrue(System.currentTimeMillis() - time >= 2000);
+   }
+
 }


### PR DESCRIPTION
(cherry picked from commit 1ee0bbf34cd3a8b9ac5994bd9195fb2c0511cbdc)

downstream: ENTMQBR-2974