### PR TITLE
ARTEMIS-2793 quorum logging implies it happens when single pair

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -430,6 +430,14 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 221080, value = "Deploying address {0} supporting {1}", format = Message.Format.MESSAGE_FORMAT)
    void deployAddress(String addressName, String routingTypes);
 
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 221083, value = "ignoring quorum vote as max cluster size is {0}.", format = Message.Format.MESSAGE_FORMAT)
+   void ignoringQuorumVote(int maxClusterSize);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 221084, value = "Requested {0} quorum votes", format = Message.Format.MESSAGE_FORMAT)
+   void requestedQuorumVotes(int vote);
+
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222000, value = "ActiveMQServer is being finalized and has not been stopped. Please remember to stop the server before letting it go out of scope",
       format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/QuorumManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/QuorumManager.java
@@ -195,8 +195,10 @@ public final class QuorumManager implements ClusterTopologyListener, ActiveMQCom
                runnables.add(voteRunnable);
             }
          }
-         if (runnables.size() > 0) {
-            voteRunnables.put(quorumVote, new VoteRunnableHolder(quorumVote, runnables, runnables.size()));
+         final int votes = runnables.size();
+         ActiveMQServerLogger.LOGGER.requestedQuorumVotes(votes);
+         if (votes > 0) {
+            voteRunnables.put(quorumVote, new VoteRunnableHolder(quorumVote, runnables, votes));
 
             for (VoteRunnable runnable : runnables) {
                executor.submit(runnable);


### PR DESCRIPTION
(cherry picked from commit 65c4c45fc235a301248035ad78852d8a4b87da45)

downstream: ENTMQBR-3639