### PR TITLE
ENTMQBR-3688 SIGSEGV in libaio when running RHEL 7.8

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -30,7 +30,7 @@
    <name>Apache ActiveMQ Artemis Distribution</name>
 
    <properties>
-      <version.org.apache.activemq.libartemis-native>1.0.0_00003-redhat-1</version.org.apache.activemq.libartemis-native>
+      <version.org.apache.activemq.libartemis-native>1.0.2-redhat-1</version.org.apache.activemq.libartemis-native>
       <schemaLocation>${project.build.directory}/${project.artifactId}-${project.version}-bin/${project.artifactId}-${project.version}/schema</schemaLocation>
       <configLocation>src/main/resources/config</configLocation>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
@@ -278,7 +278,7 @@
             <version>2.2</version>
             <executions>
                <execution>
-                  <id>copy-resources-32</id>
+                  <id>copy-resources-i686</id>
                   <phase>validate</phase>
                   <goals>
                      <goal>copy</goal>
@@ -287,7 +287,7 @@
                      <artifactItems>
                         <artifactItem>
                            <groupId>org.apache.activemq</groupId>
-                           <artifactId>libartemis-native-32</artifactId>
+                           <artifactId>libartemis-native-linux-i686</artifactId>
                            <version>${version.org.apache.activemq.libartemis-native}</version>
                            <type>so</type>
                            <outputDirectory>${basedir}/target/natives/lib/linux-i686/</outputDirectory>
@@ -297,7 +297,7 @@
                   </configuration>
                </execution>
                <execution>
-                  <id>copy-resources-64</id>
+                  <id>copy-resources-x86_64</id>
                   <phase>validate</phase>
                   <goals>
                      <goal>copy</goal>
@@ -306,7 +306,7 @@
                      <artifactItems>
                         <artifactItem>
                            <groupId>org.apache.activemq</groupId>
-                           <artifactId>libartemis-native-64</artifactId>
+                           <artifactId>libartemis-native-linux-x86_64</artifactId>
                            <version>${version.org.apache.activemq.libartemis-native}</version>
                            <type>so</type>
                            <outputDirectory>${basedir}/target/natives/lib/linux-x86_64/</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
        <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->
       <staging.siteURL>scp://people.apache.org/x1/www/activemq.apache.org</staging.siteURL>
 
-      <activemq-artemis-native-version>1.0.2</activemq-artemis-native-version>
+      <activemq-artemis-native-version>1.0.2.redhat-00001</activemq-artemis-native-version>
       <karaf.version>4.0.6</karaf.version>
       <pax.exam.version>4.9.1</pax.exam.version>
       <commons.config.version>2.7</commons.config.version>


### PR DESCRIPTION
ARTEMIS-2800 / ARTEMIS-2818 Upgrade Artemis Native
This is upgrading artemis native which has a fix to avoid a kernel bug in the fs/aio.c module
(cherry picked from commit 0e0ebd1)

NO-JIRA Update activemq-artemis-native to 1.0.2
(cherry picked from commit 053637f)

downstream: ENTMQBR-3688