### PR TITLE
NO-JIRA Avoiding intermittent failure on OpenWireLargeMessageTest

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireLargeMessageTest.java
@@ -75,7 +75,7 @@ public class OpenWireLargeMessageTest extends BasicOpenWireTest {
       addressSettingsMap.put("#", new AddressSettings().setAutoCreateQueues(false).setAutoCreateAddresses(false).setDeadLetterAddress(new SimpleString("ActiveMQ.DLQ")).setAutoCreateAddresses(true));
       addressSettingsMap.put(lmDropAddress.toString(),
                              new AddressSettings()
-                                .setMaxSizeBytes(15 * 1024 * 1024)
+                                .setMaxSizeBytes(100 * 1024)
                                 .setAddressFullMessagePolicy(AddressFullMessagePolicy.DROP)
                                 .setMessageCounterHistoryDayLimit(10)
                                 .setRedeliveryDelay(0)


### PR DESCRIPTION
(cherry picked from commit bbac2937ee2a1c0252e6664db8cc09b0369a2230)

NO-JIRA on downstream