### PR TITLE
ARTEMIS-2853 page-max-concurrent-io cannot be disabled

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -172,7 +172,8 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
 
       largeMessagesFactory = new NIOSequentialFileFactory(config.getLargeMessagesLocation(), false, criticalErrorListener, 1);
 
-      if (config.getPageMaxConcurrentIO() != 1) {
+      // it doesn't make sense to limit paging concurrency < 0
+      if (config.getPageMaxConcurrentIO() >= 0) {
          pageMaxConcurrentIO = new Semaphore(config.getPageMaxConcurrentIO());
       } else {
          pageMaxConcurrentIO = null;

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
@@ -86,6 +86,20 @@ public class JournalStorageManagerTest extends ActiveMQTestBase {
       testExecutor.shutdownNow();
    }
 
+   @Test
+   public void testDisablePageConcurrentMax() throws Exception {
+      if (journalType == JournalType.ASYNCIO) {
+         assumeTrue("AIO is not supported on this platform", AIOSequentialFileFactory.isSupported());
+      }
+      final Configuration configuration = createDefaultInVMConfig().setJournalType(journalType);
+      configuration.setPageMaxConcurrentIO(-1);
+      final ExecutorFactory executorFactory = new OrderedExecutorFactory(executor);
+      final ExecutorFactory ioExecutorFactory = new OrderedExecutorFactory(ioExecutor);
+      final JournalStorageManager manager = new JournalStorageManager(configuration, null, executorFactory, null, ioExecutorFactory);
+      // if -1 is being set it means that we should first call afterPageRead to acuire the permit to read a page
+      Assert.assertTrue(manager.beforePageRead(0, TimeUnit.NANOSECONDS));
+   }
+
    /**
     * Test of fixJournalFileSize method, of class JournalStorageManager.
     */


### PR DESCRIPTION
(cherry picked from commit f2d0d30)
downstream: ENTMQBR-3783
test: org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManagerTest#testDisablePageConcurrentMax
            component: Artemis
            subcomponent: persistence
            level: component
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            