### PR TITLE
ARTEMIS-2856 consumer can be created on closed session

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -488,4 +488,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229230, value = "Failed to bind acceptor {0} to {1}", format = Message.Format.MESSAGE_FORMAT)
    IllegalStateException failedToBind(String acceptor, String hostPort, @Cause Exception e);
+
+   @Message(id = 229232, value = "Cannot create consumer on {0}. Session is closed.", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQIllegalStateException cannotCreateConsumerOnClosedSession(SimpleString queueName);
 }


### PR DESCRIPTION
Due to a lack of concurrency protections it's possible to create a
consumer on a closed session. I've not been able to reproduce this with
a test, but I've seen it in the wild. Static code analysis points to a
need for better concurrency controls around closing the session and
creating consumers.

(cherry picked from commit cd7f52d4ba12a03cbac9f4f2d7a34c5cfe023eba)

downstream: ENTMQBR-3529