### PR TITLE
ARTEMIS-2743 Synchronize JMS connection methods

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -192,7 +192,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
     * For that reason we have this method to force that nonXASession, since the JMS Javadoc
     * mandates createSession to return a XASession.
     */
-   public Session createNonXASession(final boolean transacted, final int acknowledgeMode) throws JMSException {
+   public synchronized Session createNonXASession(final boolean transacted, final int acknowledgeMode) throws JMSException {
       checkClosed();
 
       return createSessionInternal(false, transacted, acknowledgeMode, ActiveMQConnection.TYPE_GENERIC_CONNECTION);
@@ -206,7 +206,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
     * For that reason we have this method to force that nonXASession, since the JMS Javadoc
     * mandates createSession to return a XASession.
     */
-   public Session createNonXATopicSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
+   public synchronized Session createNonXATopicSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
       checkClosed();
 
       return createSessionInternal(false, transacted, acknowledgeMode, ActiveMQConnection.TYPE_TOPIC_CONNECTION);
@@ -220,7 +220,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
     * For that reason we have this method to force that nonXASession, since the JMS Javadoc
     * mandates createSession to return a XASession.
     */
-   public Session createNonXAQueueSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
+   public synchronized Session createNonXAQueueSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
       checkClosed();
 
       return createSessionInternal(false, transacted, acknowledgeMode, ActiveMQConnection.TYPE_QUEUE_CONNECTION);
@@ -432,14 +432,14 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    }
 
    @Override
-   public Session createSession(int sessionMode) throws JMSException {
+   public synchronized Session createSession(int sessionMode) throws JMSException {
       checkClosed();
       return createSessionInternal(false, sessionMode == Session.SESSION_TRANSACTED, sessionMode, ActiveMQSession.TYPE_GENERIC_SESSION);
 
    }
 
    @Override
-   public Session createSession() throws JMSException {
+   public synchronized Session createSession() throws JMSException {
       checkClosed();
       return createSessionInternal(false, false, Session.AUTO_ACKNOWLEDGE, ActiveMQSession.TYPE_GENERIC_SESSION);
    }
@@ -447,7 +447,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    // QueueConnection implementation ---------------------------------------------------------------
 
    @Override
-   public QueueSession createQueueSession(final boolean transacted, int acknowledgeMode) throws JMSException {
+   public synchronized QueueSession createQueueSession(final boolean transacted, int acknowledgeMode) throws JMSException {
       checkClosed();
       return createSessionInternal(false, transacted, checkAck(transacted, acknowledgeMode), ActiveMQSession.TYPE_QUEUE_SESSION);
    }
@@ -477,7 +477,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    // TopicConnection implementation ---------------------------------------------------------------
 
    @Override
-   public TopicSession createTopicSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
+   public synchronized TopicSession createTopicSession(final boolean transacted, final int acknowledgeMode) throws JMSException {
       checkClosed();
       return createSessionInternal(false, transacted, checkAck(transacted, acknowledgeMode), ActiveMQSession.TYPE_TOPIC_SESSION);
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
@@ -48,20 +48,20 @@ public final class ActiveMQXAConnection extends ActiveMQConnection implements XA
    }
 
    @Override
-   public XASession createXASession() throws JMSException {
+   public synchronized XASession createXASession() throws JMSException {
       checkClosed();
       return (XASession) createSessionInternal(isXA(), true, Session.SESSION_TRANSACTED, ActiveMQSession.TYPE_GENERIC_SESSION);
    }
 
    @Override
-   public XAQueueSession createXAQueueSession() throws JMSException {
+   public synchronized XAQueueSession createXAQueueSession() throws JMSException {
       checkClosed();
       return (XAQueueSession) createSessionInternal(isXA(), true, Session.SESSION_TRANSACTED, ActiveMQSession.TYPE_QUEUE_SESSION);
 
    }
 
    @Override
-   public XATopicSession createXATopicSession() throws JMSException {
+   public synchronized XATopicSession createXATopicSession() throws JMSException {
       checkClosed();
       return (XATopicSession) createSessionInternal(isXA(), true, Session.SESSION_TRANSACTED, ActiveMQSession.TYPE_TOPIC_SESSION);
    }


### PR DESCRIPTION
(cherry picked from commit 803ccf7)
downstream: ENTMQBR-3817
test: org.apache.activemq.artemis.tests.integration.jms.client.ConnectionTest#testCreateSessionAndCloseConnectionConcurrently
            component: jms-client
            subcomponent: connections
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            