### PR TITLE
ARTEMIS-2815: Fix null pointer exception on attempt to update queue without filter

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -421,6 +421,25 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void testCreateAndUpdateQueueWithoutFilter() throws Exception {
+      SimpleString address = RandomUtil.randomSimpleString();
+      SimpleString name = RandomUtil.randomSimpleString();
+
+      ActiveMQServerControl serverControl = createManagementControl();
+
+      serverControl.createQueue(address.toString(), "ANYCAST", name.toString(), null, true, -1, false, true);
+      serverControl.updateQueue(name.toString(), "ANYCAST", 1, null, null, null);
+
+      QueueControl queueControl = ManagementControlHelper.createQueueControl(address, name, RoutingType.ANYCAST, mbeanServer);
+      Assert.assertEquals(address.toString(), queueControl.getAddress());
+      Assert.assertEquals(name.toString(), queueControl.getName());
+      Assert.assertNull(queueControl.getFilter());
+      Assert.assertEquals(1, queueControl.getMaxConsumers());
+
+      serverControl.destroyQueue(name.toString());
+   }
+
+   @Test
    public void testGetQueueNames() throws Exception {
       SimpleString address = RandomUtil.randomSimpleString();
       SimpleString name = RandomUtil.randomSimpleString();


### PR DESCRIPTION
(cherry picked from commit 3e394b4)
Conflicts:
artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
downstream: ENTMQBR-3856
test: org.apache.activemq.artemis.tests.integration.management.ActiveMQServerControlTest#testCreateAndUpdateQueueWithoutFilter
            component: Artemis
            subcomponent: management
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            