### PR TITLE
ARTEMIS-2843 non-destructive LVQ not delivering msg to consumer

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -106,6 +106,21 @@ public class LastValueQueue extends QueueImpl {
 
             replaceLVQMessage(ref, hr);
 
+            if (isNonDestructive() && hr.isDelivered()) {
+               hr.resetDelivered();
+               // --------------------------------------------------------------------------------
+               // If non Destructive, and if a reference was previously delivered
+               // we would not be able to receive this message again
+               // unless we reset the iterators
+               // The message is not removed, so we can't actually remove it
+               // a result of this operation is that previously delivered messages
+               // will probably be delivered again.
+               // if we ever want to avoid other redeliveries we would have to implement a reset or redeliver
+               // operation on the iterator for a single message
+               resetAllIterators();
+               deliverAsync();
+            }
+
          } else {
             hr = new HolderReference(prop, ref);
 
@@ -115,6 +130,18 @@ public class LastValueQueue extends QueueImpl {
          }
       } else {
          super.addTail(ref, direct);
+      }
+   }
+
+
+   @Override
+   public long getMessageCount() {
+      if (pageSubscription != null) {
+         // messageReferences will have depaged messages which we need to discount from the counter as they are
+         // counted on the pageSubscription as well
+         return (long) pendingMetrics.getMessageCount() + getScheduledCount() + pageSubscription.getMessageCount();
+      } else {
+         return (long) pendingMetrics.getMessageCount() + getScheduledCount();
       }
    }
 
@@ -236,11 +263,22 @@ public class LastValueQueue extends QueueImpl {
 
       private final SimpleString prop;
 
+      private volatile boolean delivered = false;
+
       private volatile MessageReference ref;
 
       private long consumerID;
 
       private boolean hasConsumerID = false;
+
+
+      public void resetDelivered() {
+         delivered = false;
+      }
+
+      public boolean isDelivered() {
+         return delivered;
+      }
 
       HolderReference(final SimpleString prop, final MessageReference ref) {
          this.prop = prop;
@@ -259,6 +297,7 @@ public class LastValueQueue extends QueueImpl {
 
       @Override
       public void handled() {
+         delivered = true;
          // We need to remove the entry from the map just before it gets delivered
          ref.handled();
          if (!ref.getQueue().isNonDestructive()) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -165,7 +165,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    private volatile boolean queueDestroyed = false;
 
-   private final PageSubscription pageSubscription;
+   protected final PageSubscription pageSubscription;
 
    private ReferenceCounter refCountForConsumers;
 
@@ -187,7 +187,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    // The estimate of memory being consumed by this queue. Used to calculate instances of messages to depage
    private final AtomicInteger queueMemorySize = new AtomicInteger(0);
 
-   private final QueuePendingMessageMetrics pendingMetrics = new QueuePendingMessageMetrics(this);
+   protected final QueuePendingMessageMetrics pendingMetrics = new QueuePendingMessageMetrics(this);
 
    private final QueuePendingMessageMetrics deliveringMetrics = new QueuePendingMessageMetrics(this);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/LVQTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/LVQTest.java
@@ -26,9 +26,11 @@ import javax.jms.TextMessage;
 import javax.jms.Topic;
 
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,6 +48,59 @@ public class LVQTest extends JMSTestBase {
 
    protected ConnectionFactory getCF() throws Exception {
       return cf;
+   }
+
+   @Test
+   public void testLVQandNonDestructive() throws Exception {
+      ActiveMQConnectionFactory fact = (ActiveMQConnectionFactory) getCF();
+      fact.setConsumerWindowSize(0);
+
+      try (Connection connection = fact.createConnection();
+           Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)) {
+
+         // swapping these two lines makes the test either succeed for fail
+         // Queue queue = session.createQueue("random?last-value=true");
+         Queue queue = session.createQueue("random?last-value=true&non-destructive=true");
+
+         MessageProducer producer = session.createProducer(queue);
+         MessageConsumer consumer = session.createConsumer(queue);
+
+         connection.start();
+
+         TextMessage message = session.createTextMessage();
+         message.setText("Message 1");
+         message.setStringProperty(Message.HDR_LAST_VALUE_NAME.toString(), "A");
+         producer.send(message);
+
+         TextMessage tm = (TextMessage) consumer.receive(2000);
+         assertNotNull(tm);
+         tm.acknowledge();
+
+         Thread.sleep(1000);
+         assertEquals("Message 1", tm.getText());
+
+         message = session.createTextMessage();
+         message.setText("Message 2");
+         message.setStringProperty(Message.HDR_LAST_VALUE_NAME.toString(), "A");
+         producer.send(message);
+
+         tm = (TextMessage) consumer.receive(2000);
+         assertNotNull(tm);
+         assertEquals("Message 2", tm.getText());
+
+         // It is important to query here
+         // as we shouldn't rely on addHead after the consumer is closed
+         org.apache.activemq.artemis.core.server.Queue serverQueue = server.locateQueue(SimpleString.toSimpleString("random"));
+         Wait.assertEquals(1, serverQueue::getMessageCount);
+      }
+
+      org.apache.activemq.artemis.core.server.Queue serverQueue = server.locateQueue(SimpleString.toSimpleString("random"));
+      Wait.assertEquals(1, serverQueue::getMessageCount);
+
+      serverQueue.deleteMatchingReferences(null);
+      // This should be removed all
+      assertEquals(0, serverQueue.getMessageCount());
+
    }
 
    @Test


### PR DESCRIPTION
(cherry picked from commit ccc0fa7)
Conflicts:
artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
downstream: ENTMQBR-3859
test: org.apache.activemq.artemis.tests.integration.jms.client.LVQTest#testLVQandNonDestructive
            component: jms-client
            subcomponent: message_delivery
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            