### PR TITLE
ARTEMIS-2856 consumer can be created on closed session

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -473,4 +473,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229225, value = "Validated User is not set", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQIllegalStateException rejectEmptyValidatedUser();
+
+   @Message(id = 229232, value = "Cannot create consumer on {0}. Session is closed.", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQIllegalStateException cannotCreateConsumerOnClosedSession(SimpleString queueName);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -393,6 +393,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                ActiveMQServerLogger.LOGGER.unableToRollbackOnClose(e);
             }
          }
+         closed = true;
       }
 
       //putting closing of consumers outside the sync block
@@ -430,7 +431,6 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
             callback.closed();
          }
 
-         closed = true;
          //When the ServerSessionImpl is closed, need to create and send a SESSION_CLOSED notification.
          sendSessionNotification(CoreNotificationType.SESSION_CLOSED);
 
@@ -526,8 +526,14 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                filterString, browseOnly, supportLargeMessage));
       }
 
-      ServerConsumer consumer = new ServerConsumerImpl(consumerID, this, (QueueBinding) binding, filter, priority, started, browseOnly, storageManager, callback, preAcknowledge, strictUpdateDeliveryCount, managementService, supportLargeMessage, credits, server);
-      consumers.put(consumer.getID(), consumer);
+      ServerConsumer consumer;
+      synchronized (this) {
+         if (closed) {
+            throw ActiveMQMessageBundle.BUNDLE.cannotCreateConsumerOnClosedSession(queueName);
+         }
+         consumer = new ServerConsumerImpl(consumerID, this, (QueueBinding) binding, filter, priority, started, browseOnly, storageManager, callback, preAcknowledge, strictUpdateDeliveryCount, managementService, supportLargeMessage, credits, server);
+         consumers.put(consumer.getID(), consumer);
+      }
 
       if (server.hasBrokerConsumerPlugins()) {
          server.callBrokerConsumerPlugins(plugin -> plugin.afterCreateConsumer(consumer));


### PR DESCRIPTION
Due to a lack of concurrency protections it's possible to create a
consumer on a closed session. I've not been able to reproduce this with
a test, but I've seen it in the wild. Static code analysis points to a
need for better concurrency controls around closing the session and
creating consumers.

(cherry picked from commit cd7f52d4ba12a03cbac9f4f2d7a34c5cfe023eba)

Conflicts:
artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java

downstream: ENTMQBR-3799