### PR TITLE
ARTEMIS-2869 JDBC XML conf can't use custom pwd codec

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -316,12 +316,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          config.setHAPolicyConfiguration(new LiveOnlyPolicyConfiguration());
       }
 
-      NodeList storeTypeNodes = e.getElementsByTagName("store");
-
-      if (storeTypeNodes.getLength() > 0) {
-         parseStoreConfiguration((Element) storeTypeNodes.item(0), config);
-      }
-
       config.setResolveProtocols(getBoolean(e, "resolve-protocols", config.isResolveProtocols()));
 
       config.setPersistenceEnabled(getBoolean(e, "persistence-enabled", config.isPersistenceEnabled()));
@@ -408,6 +402,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
 
       config.setClusterUser(getString(e, "cluster-user", config.getClusterUser(), Validators.NO_CHECK));
+
+      NodeList storeTypeNodes = e.getElementsByTagName("store");
+
+      if (storeTypeNodes.getLength() > 0) {
+         parseStoreConfiguration((Element) storeTypeNodes.item(0), config);
+      }
 
       NodeList interceptorNodes = e.getElementsByTagName("remoting-interceptors");
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationDbEncryptedPassTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationDbEncryptedPassTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.impl;
+
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.FileDeploymentManager;
+import org.apache.activemq.artemis.utils.SensitiveDataCodec;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileConfigurationDbEncryptedPassTest extends ConfigurationImplTest {
+
+
+   protected String getConfigurationName() {
+      return "ConfigurationTest-db-encrypted-pass-config.xml";
+   }
+
+   @Override
+   @Test
+   public void testDefaults() {
+      // empty
+   }
+
+   @Test
+   public void testJdbcPasswordWithCustomCodec() {
+      Assert.assertTrue(MySensitiveStringCodec.decoded);
+   }
+
+   @Override
+   protected Configuration createConfiguration() throws Exception {
+      FileConfiguration fc = new FileConfiguration();
+      FileDeploymentManager deploymentManager = new FileDeploymentManager(getConfigurationName());
+      deploymentManager.addDeployable(fc);
+      deploymentManager.readConfiguration();
+      return fc;
+   }
+
+   public static class MySensitiveStringCodec implements SensitiveDataCodec<String> {
+      public static boolean decoded = false;
+
+      @Override
+      public String decode(Object mask) throws Exception {
+         decoded = true;
+         return null;
+      }
+
+      @Override
+      public String encode(Object secret) throws Exception {
+         return null;
+      }
+   }
+}

--- a/artemis-server/src/test/resources/ConfigurationTest-db-encrypted-pass-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-db-encrypted-pass-config.xml
@@ -1,0 +1,38 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration
+        xmlns="urn:activemq"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:activemq ../../../../activemq-server/src/main/resources/schema/artemis-server.xsd">
+   <core xmlns="urn:activemq:core">
+
+      <password-codec>org.apache.activemq.artemis.core.config.impl.FileConfigurationDbEncryptedPassTest$MySensitiveStringCodec</password-codec>
+
+      <store>
+         <database-store>
+            <jdbc-driver-class-name>foo</jdbc-driver-class-name>
+            <jdbc-connection-url>foo</jdbc-connection-url>
+            <message-table-name>foo</message-table-name>
+            <bindings-table-name>foo</bindings-table-name>
+            <large-message-table-name>foo</large-message-table-name>
+            <page-store-table-name>foo</page-store-table-name>
+            <jdbc-password>ENC(foo)</jdbc-password>
+         </database-store>
+      </store>
+
+   </core>
+</configuration>


### PR DESCRIPTION
(cherry picked from commit 1ae8069)
downstream: ENTMQBR-3861
test: org.apache.activemq.artemis.core.config.impl.FileConfigurationDbEncryptedPassTest#testDefaults,org.apache.activemq.artemis.core.config.impl.FileConfigurationDbEncryptedPassTest#testJdbcPasswordWithCustomCodec
            component: Artemis
            subcomponent: configuration
            level: component
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            