### PR TITLE
ARTEMIS-2881 deadlock when destroying q and depaging

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
@@ -52,6 +52,8 @@ public class TransientQueueManagerImpl extends ReferenceCounterUtil implements T
    }
 
    public TransientQueueManagerImpl(ActiveMQServer server, SimpleString queueName) {
+      super(server.getExecutorFactory().getExecutor());
+
       this.server = server;
 
       this.queueName = queueName;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/SharedConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/SharedConsumerTest.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -95,8 +96,7 @@ public class SharedConsumerTest extends JMSTestBase {
          Binding binding = server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon"));
          assertNotNull(binding);
          con2.close();
-         binding = server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon"));
-         assertNull(binding);
+         Wait.assertTrue(() -> server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon")) == null, 2000, 100);
          con1 = context.createSharedConsumer(topic2, "mySharedCon");
       } finally {
          context.close();


### PR DESCRIPTION
I couldn't reproduce this with a test, but static code analysis led me
to this solution which is similar to the fix done for ARTEMIS-2592 via
e397a17.
(cherry picked from commit fa5b56e)
Conflicts:
tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
downstream: ENTMQBR-3864
test: org.apache.activemq.artemis.tests.integration.client.TransientQueueTest#testMultipleConsumers,org.apache.activemq.artemis.tests.integration.jms.jms2client.SharedConsumerTest#sharedNonDurableUnsubscribeDifferentTopic
            component: Artemis
            subcomponent: queuing
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            