### PR TITLE
ARTEMIS-2895 - ensure propagated credentials are visible for bind and removed for subsequent mapping operations

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
@@ -550,6 +550,7 @@ public class LDAPLoginModule implements LoginModule {
       if (logger.isDebugEnabled()) {
          logger.debug("Binding the user.");
       }
+      context.addToEnvironment(Context.SECURITY_AUTHENTICATION, "simple");
       context.addToEnvironment(Context.SECURITY_PRINCIPAL, dn);
       context.addToEnvironment(Context.SECURITY_CREDENTIALS, password);
       try {
@@ -575,6 +576,7 @@ public class LDAPLoginModule implements LoginModule {
       } else {
          context.removeFromEnvironment(Context.SECURITY_CREDENTIALS);
       }
+      context.addToEnvironment(Context.SECURITY_AUTHENTICATION, getLDAPPropertyValue(AUTHENTICATION));
 
       return isValid;
    }

--- a/artemis-server/src/test/resources/login.config
+++ b/artemis-server/src/test/resources/login.config
@@ -89,6 +89,26 @@ UnAuthenticatedLDAPLogin {
         ;
 };
 
+AnonBindCheckUserLDAPLogin {
+    org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule required
+        debug=true
+        initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+        connectionURL="ldap://localhost:1024"
+        connectionUsername=none
+        connectionPassword=none
+        connectionProtocol=s
+        authentication=none
+        authenticateUser=true
+        userBase="ou=system"
+        userSearchMatching="(uid={0})"
+        userSearchSubtree=false
+        roleBase="ou=system"
+        roleName=cn
+        roleSearchMatching="(member=uid={1},ou=system)"
+        roleSearchSubtree=false
+        ;
+};
+
 ExpandedLDAPLogin {
     org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule required
         debug=true

--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -704,7 +704,7 @@ system. It is implemented by
 
 - `authenticateUser` - boolean flag to disable authentication. Useful as an
   optimisation when this module is used just for role mapping of a Subject's
-  existing authenticated principals; default is `false`.
+  existing authenticated principals; default is `true`.
 
 - `referral` - specify how to handle referrals; valid values: `ignore`,
   `follow`, `throw`; default is `ignore`.


### PR DESCRIPTION
(cherry picked from commit ec1c5a96c74b24f2c9a6f0919a1a180721c5c6b9)

downstream: ENTMQBR-3867