### PR TITLE
NO-JIRA fix LegacyLDAPSecuritySettingPluginListenerTest#testNewUserAndRole

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginListenerTest.java
@@ -399,7 +399,7 @@ public class LegacyLDAPSecuritySettingPluginListenerTest extends AbstractLdapTes
          DirContext ctx = getContext();
          BasicAttributes basicAttributes = new BasicAttributes();
          basicAttributes.put("uniquemember", "cn=role3");
-         ctx.modifyAttributes("cn=write,cn=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system", DirContext.ADD_ATTRIBUTE, basicAttributes);
+         ctx.modifyAttributes("cn=write,uid=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system", DirContext.ADD_ATTRIBUTE, basicAttributes);
          ctx.close();
       }
 


### PR DESCRIPTION
method testNewUserAndRole in LegacyLDAPSecuritySettingPluginListenerTest class
was using 'cn=queue1' when try modify the permission to include write rights instead of 'uid=queue1'