### PR TITLE
ARTEMIS-2896 RA can double legacy prefix

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
@@ -140,7 +140,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
 
             boolean selectorChanged = selector == null && oldFilterString != null || oldFilterString == null && selector != null || (oldFilterString != null && selector != null && !oldFilterString.toString().equals(selector));
 
-            SimpleString oldTopicName = (enable1XPrefix ? PacketImpl.OLD_TOPIC_PREFIX : SimpleString.toSimpleString("")).concat(subResponse.getAddress());
+            SimpleString oldTopicName = (enable1XPrefix && !subResponse.getAddress().startsWith(PacketImpl.OLD_TOPIC_PREFIX) ? PacketImpl.OLD_TOPIC_PREFIX : SimpleString.toSimpleString("")).concat(subResponse.getAddress());
 
             boolean topicChanged = !oldTopicName.equals(activation.getAddress());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQMessageHandlerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQMessageHandlerTest.java
@@ -88,16 +88,28 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
 
    @Test
    public void testDurableTopicSubscriptionWith1xPrefixesOnSpec() throws Exception {
-      internalTestDurableTopicSubscriptionWith1xPrefixes(false);
+      internalTestDurableTopicSubscriptionWith1xPrefixes(false, true);
    }
 
    @Test
    public void testDurableTopicSubscriptionWith1xPrefixesOnRA() throws Exception {
-      internalTestDurableTopicSubscriptionWith1xPrefixes(true);
+      internalTestDurableTopicSubscriptionWith1xPrefixes(true, true);
    }
 
-   public void internalTestDurableTopicSubscriptionWith1xPrefixes(boolean ra) throws Exception {
-      server.getRemotingService().createAcceptor("test", "tcp://localhost:61617?anycastPrefix=jms.queue.;multicastPrefix=jms.topic.").start();
+   @Test
+   public void testDurableTopicSubscriptionWith1xPrefixesOnSpecWithoutBrokerPrefixes() throws Exception {
+      internalTestDurableTopicSubscriptionWith1xPrefixes(false, false);
+   }
+
+   @Test
+   public void testDurableTopicSubscriptionWith1xPrefixesOnRAWithoutBrokerPrefixes() throws Exception {
+      internalTestDurableTopicSubscriptionWith1xPrefixes(true, false);
+   }
+
+   public void internalTestDurableTopicSubscriptionWith1xPrefixes(boolean ra, boolean definePrefixesOnBroker) throws Exception {
+      if (definePrefixesOnBroker) {
+         server.getRemotingService().createAcceptor("test", "tcp://localhost:61617?anycastPrefix=jms.queue.;multicastPrefix=jms.topic.").start();
+      }
       ActiveMQResourceAdapter qResourceAdapter = newResourceAdapter();
       if (ra) {
          qResourceAdapter.setEnable1xPrefixes(true);
@@ -118,13 +130,21 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
       spec.setClientId("myClientId");
       spec.setSubscriptionName("mySubscriptionName");
       qResourceAdapter.setConnectorClassName(NETTY_CONNECTOR_FACTORY);
-      qResourceAdapter.setConnectionParameters("host=localhost;port=61617");
+      String port = "61616";
+      if (definePrefixesOnBroker) {
+         port = "61617";
+      }
+      qResourceAdapter.setConnectionParameters("host=localhost;port=" + port);
       CountDownLatch latch = new CountDownLatch(1);
       DummyMessageEndpoint endpoint = new DummyMessageEndpoint(latch);
       DummyMessageEndpointFactory endpointFactory = new DummyMessageEndpointFactory(endpoint, false);
       qResourceAdapter.endpointActivation(endpointFactory, spec);
       ClientSession session = locator.createSessionFactory().createSession();
-      ClientProducer clientProducer = session.createProducer("MyTopic");
+      String topic = "MyTopic";
+      if (!definePrefixesOnBroker) {
+         topic = "jms.topic." + topic;
+      }
+      ClientProducer clientProducer = session.createProducer(topic);
       ClientMessage message = session.createMessage(true);
       message.getBodyBuffer().writeString("teststring");
       clientProducer.send(message);


### PR DESCRIPTION
(cherry picked from commit 676bb10)
downstream: ENTMQBR-3816
test: org.apache.activemq.artemis.tests.integration.ra.ActiveMQMessageHandlerTest#testDurableTopicSubscriptionWith1xPrefixesOnSpecWithoutBrokerPrefixes,org.apache.activemq.artemis.tests.integration.ra.ActiveMQMessageHandlerTest#testDurableTopicSubscriptionWith1xPrefixesOnRAWithoutBrokerPrefixes
            component: Artemis
            subcomponent: queuing
            level: integration
            importance: medium
            type: functional
            subtype: compliance
            verifies: AMQ-90
            