### PR TITLE
ARTEMIS-2986 deleting scheduled messages not permanent

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.filter.Filter;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 
 public interface ScheduledDeliveryHandler {
 
@@ -37,5 +38,7 @@ public interface ScheduledDeliveryHandler {
 
    List<MessageReference> cancel(Filter filter) throws ActiveMQException;
 
-   MessageReference removeReferenceWithID(long id) throws ActiveMQException;
+   MessageReference removeReferenceWithID(long id) throws Exception;
+
+   MessageReference removeReferenceWithID(long id, Transaction tx) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2268,7 +2268,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
          if (!deleted) {
             // Look in scheduled deliveries
-            deleted = scheduledDeliveryHandler.removeReferenceWithID(messageID) != null ? true : false;
+            deleted = scheduledDeliveryHandler.removeReferenceWithID(messageID, tx) != null ? true : false;
          }
 
          tx.commit();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ScheduledDeliveryHandler;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.jboss.logging.Logger;
 
 /**
@@ -135,12 +136,18 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
    }
 
    @Override
-   public MessageReference removeReferenceWithID(final long id) throws ActiveMQException {
+   public MessageReference removeReferenceWithID(final long id) throws Exception {
+      return removeReferenceWithID(id, null);
+   }
+
+   @Override
+   public MessageReference removeReferenceWithID(final long id, Transaction tx) throws Exception {
       synchronized (scheduledReferences) {
          Iterator<RefScheduled> iter = scheduledReferences.iterator();
          while (iter.hasNext()) {
             MessageReference ref = iter.next().getRef();
             if (ref.getMessage().getMessageID() == id) {
+               ref.acknowledge(tx);
                iter.remove();
                metrics.decrementMetrics(ref);
                return ref;


### PR DESCRIPTION
When deleting a durable scheduled message via the management API the
message would be removed from memory but it wouldn't be removed from
storage so when the broker restarted the message would reappear.

This commit fixes that by acking the message during the delete
operation.

(cherry picked from commit 4bb9ed2d4e22f0a7f0925f921df83a3266551291)

downstream: ENTMQBR-4195