### PR TITLE
ARTEMIS-2954 RA doesn't use the RA specified prefix when setting up a destination

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -597,12 +597,12 @@ public class ActiveMQActivation {
       if (spec.getTopicPrefix() == null) {
          if (spec.isEnable1xPrefixes() == null) {
             if (ra.isEnable1xPrefixes() != null && ra.isEnable1xPrefixes() && !topic.startsWith(PacketImpl.OLD_TOPIC_PREFIX.toString())) {
-               return PacketImpl.OLD_TOPIC_PREFIX.toString();
+               return PacketImpl.OLD_TOPIC_PREFIX.toString() + topic;
             }
             return topic;
          }
          if (spec.isEnable1xPrefixes() && !topic.startsWith(PacketImpl.OLD_TOPIC_PREFIX.toString())) {
-            return PacketImpl.OLD_TOPIC_PREFIX.toString();
+            return PacketImpl.OLD_TOPIC_PREFIX.toString() + topic;
          }
          return topic;
       }
@@ -613,12 +613,12 @@ public class ActiveMQActivation {
       if (spec.getQueuePrefix() == null) {
          if (spec.isEnable1xPrefixes() == null) {
             if (ra.isEnable1xPrefixes() != null && ra.isEnable1xPrefixes() && !queue.startsWith(PacketImpl.OLD_QUEUE_PREFIX.toString())) {
-               return PacketImpl.OLD_QUEUE_PREFIX.toString();
+               return PacketImpl.OLD_QUEUE_PREFIX.toString() + queue;
             }
             return queue;
          }
          if (spec.isEnable1xPrefixes() && !queue.startsWith(PacketImpl.OLD_QUEUE_PREFIX.toString())) {
-            return PacketImpl.OLD_QUEUE_PREFIX.toString();
+            return PacketImpl.OLD_QUEUE_PREFIX.toString() + queue;
          }
          return queue;
       }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-20393
Upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-2954
Upstream PRs: https://github.com/apache/activemq-artemis/pull/3307, https://github.com/apache/activemq-artemis/pull/3310, https://github.com/apache/activemq-artemis/pull/3313
Downstream issue: https://issues.redhat.com/browse/ENTMQBR-4132