### PR TITLE
ARTEMIS-2986 deleting scheduled messages not permanent

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.filter.Filter;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 
 public interface ScheduledDeliveryHandler {
 
@@ -37,5 +38,7 @@ public interface ScheduledDeliveryHandler {
 
    List<MessageReference> cancel(Filter filter) throws ActiveMQException;
 
-   MessageReference removeReferenceWithID(long id) throws ActiveMQException;
+   MessageReference removeReferenceWithID(long id) throws Exception;
+
+   MessageReference removeReferenceWithID(long id, Transaction tx) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -1986,7 +1986,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
          if (!deleted) {
             // Look in scheduled deliveries
-            deleted = scheduledDeliveryHandler.removeReferenceWithID(messageID) != null ? true : false;
+            deleted = scheduledDeliveryHandler.removeReferenceWithID(messageID, tx) != null ? true : false;
          }
 
          tx.commit();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ScheduledDeliveryHandler;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.jboss.logging.Logger;
 
 /**
@@ -135,12 +136,18 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
    }
 
    @Override
-   public MessageReference removeReferenceWithID(final long id) throws ActiveMQException {
+   public MessageReference removeReferenceWithID(final long id) throws Exception {
+      return removeReferenceWithID(id, null);
+   }
+
+   @Override
+   public MessageReference removeReferenceWithID(final long id, Transaction tx) throws Exception {
       synchronized (scheduledReferences) {
          Iterator<RefScheduled> iter = scheduledReferences.iterator();
          while (iter.hasNext()) {
             MessageReference ref = iter.next().getRef();
             if (ref.getMessage().getMessageID() == id) {
+               ref.acknowledge(tx);
                iter.remove();
                metrics.decrementMetrics(ref);
                return ref;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -72,6 +72,7 @@ import org.apache.activemq.artemis.tests.integration.jms.server.management.JMSUt
 import org.apache.activemq.artemis.utils.Base64;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1803,6 +1804,44 @@ public class QueueControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void testRemoveScheduledMessageRestart() throws Exception {
+      Assume.assumeTrue(durable);
+      SimpleString address = RandomUtil.randomSimpleString();
+      SimpleString queue = RandomUtil.randomSimpleString();
+
+      session.createQueue(address, RoutingType.MULTICAST, queue, null, durable);
+      ClientProducer producer = session.createProducer(address);
+
+      // send 2 messages on queue, both scheduled
+      long timeout = System.currentTimeMillis() + 5000;
+      ClientMessage m1 = session.createMessage(durable);
+      m1.putLongProperty(Message.HDR_SCHEDULED_DELIVERY_TIME, timeout);
+      producer.send(m1);
+      ClientMessage m2 = session.createMessage(durable);
+      m2.putLongProperty(Message.HDR_SCHEDULED_DELIVERY_TIME, timeout);
+      producer.send(m2);
+
+      QueueControl queueControl = createManagementControl(address, queue);
+      assertScheduledMetrics(queueControl, 2, durable);
+
+      // the message IDs are set on the server
+      Map<String, Object>[] messages = queueControl.listScheduledMessages();
+      Assert.assertEquals(2, messages.length);
+      long messageID = (Long) messages[0].get("messageID");
+
+      // delete 1st message
+      boolean deleted = queueControl.removeMessage(messageID);
+      Assert.assertTrue(deleted);
+      assertScheduledMetrics(queueControl, 1, durable);
+
+      locator.close();
+      server.stop();
+      server.start();
+
+      assertScheduledMetrics(queueControl, 1, durable);
+   }
+
+   @Test
    public void testRemoveMessage2() throws Exception {
       SimpleString address = RandomUtil.randomSimpleString();
       SimpleString queue = RandomUtil.randomSimpleString();
@@ -3029,7 +3068,7 @@ public class QueueControlTest extends ManagementTestBase {
    public void setUp() throws Exception {
       super.setUp();
       Configuration conf = createDefaultInVMConfig().setJMXManagementEnabled(true);
-      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, false));
+      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, true));
 
       server.start();
 


### PR DESCRIPTION
When deleting a durable scheduled message via the management API the
message would be removed from memory but it wouldn't be removed from
storage so when the broker restarted the message would reappear.

This commit fixes that by acking the message during the delete
operation.

(cherry picked from commit 4bb9ed2d4e22f0a7f0925f921df83a3266551291)

downstream: ENTMQBR-4425