### PR TITLE
ARTEMIS-2802: Add a null check when checking matching metaData inside

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueue.java
@@ -143,7 +143,8 @@ public class FederatedQueue extends FederatedAbstract implements ActiveMQServerC
       //We check the session meta data to see if its a federation session, if so by default we ignore these.
       //To not ignore these, set include-federated to true, which will mean no meta data filter.
       ServerSession serverSession = server.getSessionByID(consumer.getSessionID());
-      if (metaDataFilter != null && serverSession != null && metaDataFilter.match(serverSession.getMetaData())) {
+      if (metaDataFilter != null && serverSession != null && serverSession.getMetaData() != null &&
+          metaDataFilter.match(serverSession.getMetaData())) {
          return;
       }
       if (match(consumer)) {


### PR DESCRIPTION
Federated Queue

Other protocols besides CORE may not have a metadata map so we need to
check for null before passing to the filter matcher

(cherry picked from commit 4c4d7a71cbd665b75aab8bd33f4719220e4dea7d)

downstream: ENTMQBR-4617