### PR TITLE
NO-JIRA fix log message format in ActiveMQRALogger

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRALogger.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRALogger.java
@@ -155,10 +155,10 @@ public interface ActiveMQRALogger extends BasicLogger {
    void invalidAcknowledgementMode(String mode);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 153004, value = "Invalid number of session (negative) '{0}', defaulting to '${1}'.", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 153004, value = "Invalid number of session (negative) {0}, defaulting to {1}.", format = Message.Format.MESSAGE_FORMAT)
    void invalidNumberOfMaxSession(int value, int defaultValue);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 153005, value =  "Unable to retrieve '${0}' from JNDI. Creating a new '${1}' named '${2}' to be used by the MDB.", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 153005, value =  "Unable to retrieve \"{0}\" from JNDI. Creating a new \"{1}\" named \"{2}\" to be used by the MDB.", format = Message.Format.MESSAGE_FORMAT)
    void unableToRetrieveDestinationName(String destinationName, String name, String calculatedDestinationName);
 }


### PR DESCRIPTION
Wrong log message format - parameters are not substituted.

This is backport to 2.9.0.x branch.

Upstream commit: https://github.com/apache/activemq-artemis/commit/1b5ed3d1a4d28d0291123cd5414bacdb1ca5d824
JBEAP Issue: https://issues.redhat.com/browse/JBEAP-21831