### PR TITLE
ARTEMIS-3261 Updating logic to use only replaceable records on compacting verification

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/CompactJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/CompactJournal.java
@@ -59,11 +59,11 @@ public final class CompactJournal extends LockAbstract {
                                final int poolFiles,
                                final int fileSize,
                                final IOCriticalErrorListener listener,
-                               int... replaceableRecords) throws Exception {
+                               byte... replaceableRecords) throws Exception {
       NIOSequentialFileFactory nio = new NIOSequentialFileFactory(directory, listener, 1);
 
       JournalImpl journal = new JournalImpl(fileSize, minFiles, poolFiles, 0, 0, nio, journalPrefix, journalSuffix, 1);
-      for (int i : replaceableRecords) {
+      for (byte i : replaceableRecords) {
          journal.replaceableRecord(i);
       }
       journal.setRemoveExtraFilesOnLoad(true);

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
@@ -87,7 +87,7 @@ public interface Journal extends ActiveMQComponent {
       appendAddRecord(id, recordType, EncoderPersister.getInstance(), record, sync, completionCallback);
    }
 
-   default void replaceableRecord(int recordType) {
+   default void replaceableRecord(byte recordType) {
    }
 
    void appendUpdateRecord(long id, byte recordType, byte[] record, boolean sync) throws Exception;

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
@@ -59,7 +59,7 @@ public final class FileWrapperJournal extends JournalBase {
    protected volatile JournalFile currentFile;
 
    @Override
-   public void replaceableRecord(int recordType) {
+   public void replaceableRecord(byte recordType) {
       journal.replaceableRecord(recordType);
    }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFile.java
@@ -32,6 +32,10 @@ public interface JournalFile {
 
    void decPosCount();
 
+   int getReplaceableCount();
+
+   void incReplaceableCount();
+
    void incAddRecord();
 
    int getAddRecord();

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFileImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFileImpl.java
@@ -35,10 +35,12 @@ public class JournalFileImpl implements JournalFile {
 
    private long offset;
 
+   private static final AtomicIntegerFieldUpdater<JournalFileImpl> replaceableCountUpdater = AtomicIntegerFieldUpdater.newUpdater(JournalFileImpl.class, "replaceableCountField");
    private static final AtomicIntegerFieldUpdater<JournalFileImpl> posCountUpdater = AtomicIntegerFieldUpdater.newUpdater(JournalFileImpl.class, "posCountField");
    private static final AtomicIntegerFieldUpdater<JournalFileImpl> addRecordUpdate = AtomicIntegerFieldUpdater.newUpdater(JournalFileImpl.class, "addRecordField");
    private static final AtomicIntegerFieldUpdater<JournalFileImpl> liveBytesUpdater = AtomicIntegerFieldUpdater.newUpdater(JournalFileImpl.class, "liveBytesField");
 
+   private volatile int replaceableCountField = 0;
    private volatile int posCountField = 0;
    private volatile int addRecordField = 0;
    private volatile int liveBytesField = 0;
@@ -68,6 +70,16 @@ public class JournalFileImpl implements JournalFile {
    @Override
    public int getPosCount() {
       return posCountUpdater.get(this);
+   }
+
+   @Override
+   public int getReplaceableCount() {
+      return replaceableCountUpdater.get(this);
+   }
+
+   @Override
+   public void incReplaceableCount() {
+      replaceableCountUpdater.incrementAndGet(this);
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 
+import io.netty.util.collection.ByteObjectHashMap;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
@@ -106,6 +106,8 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
     *
     * To update this value, define a System Property org.apache.activemq.artemis.core.journal.impl.JournalImpl.UPDATE_FACTOR=YOUR VALUE
     *
+    * We only calculate this against replaceable updates, on this case for redelivery counts and rescheduled redelivery in artemis server
+    *
     * */
    public static final double UPDATE_FACTOR;
 
@@ -114,7 +116,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       double value;
       try {
          if (UPDATE_FACTOR_STR == null) {
-            value = 100;
+            value = 10;
          } else {
             value = Double.parseDouble(UPDATE_FACTOR_STR);
          }
@@ -240,19 +242,25 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    private final ReadWriteLock journalLock = new ReentrantReadWriteLock();
    private final ReadWriteLock compactorLock = new ReentrantReadWriteLock();
 
-   HashSet<Integer> replaceableRecords;
+   ByteObjectHashMap<Boolean> replaceableRecords;
 
 
    /** This will declare a record type as being replaceable on updates.
     * Certain update records only need the last value, and they could be replaceable during compacting.
     * */
    @Override
-   public void replaceableRecord(int recordType) {
+   public void replaceableRecord(byte recordType) {
       if (replaceableRecords == null) {
-         replaceableRecords = new HashSet<>();
+         replaceableRecords = new ByteObjectHashMap<>();
       }
-      replaceableRecords.add(recordType);
+      replaceableRecords.put(recordType, Boolean.TRUE);
    }
+
+   @Override
+   public boolean isReplaceableRecord(byte recordType) {
+      return replaceableRecords != null && replaceableRecords.containsKey(recordType);
+   }
+
 
    private volatile JournalFile currentFile;
 
@@ -999,9 +1007,9 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                // record==null here could only mean there is a compactor
                // computing the delete should be done after compacting is done
                if (jrnRecord == null) {
-                  compactor.addCommandUpdate(id, usedFile, updateRecord.getEncodeSize());
+                  compactor.addCommandUpdate(id, usedFile, updateRecord.getEncodeSize(), recordType);
                } else {
-                  jrnRecord.addUpdateFile(usedFile, updateRecord.getEncodeSize());
+                  jrnRecord.addUpdateFile(usedFile, updateRecord.getEncodeSize(), isReplaceableRecord(recordType));
                }
 
                result.set(true);
@@ -1158,7 +1166,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                                   usedFile);
                }
 
-               tx.addPositive(usedFile, id, encodeSize);
+               tx.addPositive(usedFile, id, encodeSize, recordType);
             } catch (Throwable e) {
                logger.error("appendAddRecordTransactional:" + e, e);
                setErrorCondition(null, tx, e);
@@ -1260,7 +1268,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                           usedFile );
                }
 
-               tx.addPositive( usedFile, id, updateRecordTX.getEncodeSize() );
+               tx.addPositive( usedFile, id, updateRecordTX.getEncodeSize(), recordType);
             } catch (Throwable e ) {
                logger.error("appendUpdateRecordTransactional:" +  e.getMessage(), e );
                setErrorCondition(null, tx, e );
@@ -1894,7 +1902,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          compactor = new JournalCompactor(fileFactory, this, filesRepository, records.keysLongHashSet(), dataFilesToProcess.get(0).getFileID());
 
          if (replaceableRecords != null) {
-            replaceableRecords.forEach((i) -> compactor.replaceableRecord(i));
+            replaceableRecords.forEach((k, v) -> compactor.replaceableRecord(k));
          }
 
          transactions.forEach((id, pendingTransaction) -> {
@@ -2029,7 +2037,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                   // have been deleted
                   // just leaving some updates in this file
 
-                  posFiles.addUpdateFile(file, info.data.length + JournalImpl.SIZE_ADD_RECORD + 1); // +1 = compact
+                  posFiles.addUpdateFile(file, info.data.length + JournalImpl.SIZE_ADD_RECORD + 1, isReplaceableRecord(info.userRecordType)); // +1 = compact
                   // count
                }
             }
@@ -2077,7 +2085,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                   transactions.put(transactionID, tnp);
                }
 
-               tnp.addPositive(file, info.id, info.data.length + JournalImpl.SIZE_ADD_RECORD_TX + 1); // +1 = compact
+               tnp.addPositive(file, info.id, info.data.length + JournalImpl.SIZE_ADD_RECORD_TX + 1, info.userRecordType); // +1 = compact
                // count
             }
 
@@ -2346,7 +2354,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
 
       for (JournalFile file : dataFiles) {
          totalLiveSize += file.getLiveSize();
-         updateCount += file.getPosCount();
+         updateCount += file.getReplaceableCount();
          addRecord += file.getAddRecord();
       }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalRecord.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalRecord.java
@@ -46,7 +46,7 @@ public class JournalRecord {
       addFile.incAddRecord();
    }
 
-   void addUpdateFile(final JournalFile updateFile, final int bytes) {
+   void addUpdateFile(final JournalFile updateFile, final int bytes, boolean replaceableUpdate) {
       checkNotDeleted();
       if (bytes == 0) {
          return;
@@ -66,6 +66,9 @@ public class JournalRecord {
       fileUpdates.add(updateFile, bytes, 1);
       updateFile.incPosCount();
       updateFile.addSize(bytes);
+      if (replaceableUpdate) {
+         updateFile.incReplaceableCount();
+      }
    }
 
    void delete(final JournalFile file) {

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalRecordProvider.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalRecordProvider.java
@@ -30,4 +30,6 @@ public interface JournalRecordProvider {
    JournalCompactor getCompactor();
 
    ConcurrentLongHashMap<JournalRecord> getRecords();
+
+   boolean isReplaceableRecord(byte recordType);
 }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
@@ -202,7 +202,7 @@ public class JournalTransaction {
       }
    }
 
-   public void addPositive(final JournalFile file, final long id, final int size) {
+   public void addPositive(final JournalFile file, final long id, final int size, final byte userRecordType) {
       incCounter(file);
 
       addFile(file);
@@ -211,7 +211,7 @@ public class JournalTransaction {
          pos = new ArrayList<>();
       }
 
-      pos.add(new JournalUpdate(file, id, size));
+      pos.add(new JournalUpdate(file, id, size, userRecordType));
    }
 
    public void addNegative(final JournalFile file, final long id) {
@@ -223,7 +223,7 @@ public class JournalTransaction {
          neg = new ArrayList<>();
       }
 
-      neg.add(new JournalUpdate(file, id, 0));
+      neg.add(new JournalUpdate(file, id, 0, (byte)0));
    }
 
    /**
@@ -254,13 +254,13 @@ public class JournalTransaction {
                   // This is a case where the transaction was opened after compacting was started,
                   // but the commit arrived while compacting was working
                   // We need to cache the counter update, so compacting will take the correct files when it is done
-                  compactor.addCommandUpdate(trUpdate.id, trUpdate.file, trUpdate.size);
+                  compactor.addCommandUpdate(trUpdate.id, trUpdate.file, trUpdate.size, trUpdate.userRecordType);
                } else if (posFiles == null) {
                   posFiles = new JournalRecord(trUpdate.file, trUpdate.size);
 
                   journal.getRecords().put(trUpdate.id, posFiles);
                } else {
-                  posFiles.addUpdateFile(trUpdate.file, trUpdate.size);
+                  posFiles.addUpdateFile(trUpdate.file, trUpdate.size, journal.isReplaceableRecord(trUpdate.userRecordType));
                }
             }
          }
@@ -397,16 +397,19 @@ public class JournalTransaction {
 
       int size;
 
+      final byte userRecordType;
+
       /**
        * @param file
        * @param id
        * @param size
        */
-      private JournalUpdate(final JournalFile file, final long id, final int size) {
+      private JournalUpdate(final JournalFile file, final long id, final int size, final byte userRecordType) {
          super();
          this.file = file;
          this.id = id;
          this.size = size;
+         this.userRecordType = userRecordType;
       }
 
       /**

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/ReclaimerTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/ReclaimerTest.java
@@ -745,6 +745,16 @@ public class ReclaimerTest extends ActiveMQTestBase {
       }
 
       @Override
+      public int getReplaceableCount() {
+         return 0;
+      }
+
+      @Override
+      public void incReplaceableCount() {
+
+      }
+
+      @Override
       public void incAddRecord() {
 
       }


### PR DESCRIPTION

(cherry picked from commit 0edf599adca9365993579a96d717ed2f3c0d0af9)

downstream: ENTMQBR-4831

Note: This commit was actually originally developed as part of 2.16.0.jbossorg-x and then cherry-picked into upstream and rebased there.