### PR TITLE
ARTEMIS-3155 support better backwards compatibility

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -430,6 +430,14 @@ public interface ActiveMQClientLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void connectionFactoryParameterIgnored(String parameterName);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 212079, value = "The upstream connector from the downstream federation will ignore url parameter {0}", format = Message.Format.MESSAGE_FORMAT)
+   void ignoredParameterForDownstreamFederation(String name);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 212080, value = "Using legacy SSL store provider value: {0}. Please use either ''keyStoreType'' or ''trustStoreType'' instead as appropriate.", format = Message.Format.MESSAGE_FORMAT)
+   void oldStoreProvider(String value);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 214000, value = "Failed to call onMessage", format = Message.Format.MESSAGE_FORMAT)
    void onMessageError(@Cause Throwable e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -291,17 +291,23 @@ public class NettyAcceptor extends AbstractAcceptor {
       host = ConfigurationHelper.getStringProperty(TransportConstants.HOST_PROP_NAME, TransportConstants.DEFAULT_HOST, configuration);
       port = ConfigurationHelper.getIntProperty(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_PORT, configuration);
       if (sslEnabled) {
-         keyStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_PROVIDER, configuration);
+         Pair<String, String> keyStoreCompat = SSLSupport.getValidProviderAndType(ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_PROVIDER, configuration),
+                                                                                  ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_TYPE_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_TYPE, configuration));
 
-         keyStoreType = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_TYPE_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_TYPE, configuration);
+         keyStoreProvider = keyStoreCompat.getA();
+
+         keyStoreType = keyStoreCompat.getB();
 
          keyStorePath = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PATH_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_PATH, configuration);
 
          keyStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, TransportConstants.DEFAULT_KEYSTORE_PASSWORD, configuration, ActiveMQDefaultConfiguration.getPropMaskPassword(), ActiveMQDefaultConfiguration.getPropPasswordCodec());
 
-         trustStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME, TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER, configuration);
+         Pair<String, String> trustStoreCompat = SSLSupport.getValidProviderAndType(ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME, TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER, configuration),
+                                                                                    ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_TYPE_PROP_NAME, TransportConstants.DEFAULT_TRUSTSTORE_TYPE, configuration));
 
-         trustStoreType = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_TYPE_PROP_NAME, TransportConstants.DEFAULT_TRUSTSTORE_TYPE, configuration);
+         trustStoreProvider = trustStoreCompat.getA();
+
+         trustStoreType = trustStoreCompat.getB();
 
          trustStorePath = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PATH_PROP_NAME, TransportConstants.DEFAULT_TRUSTSTORE_PATH, configuration);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -43,10 +44,12 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec;
 import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
 import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,19 +63,23 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
    @Parameterized.Parameters(name = "storeProvider={0}, storeType={1}")
    public static Collection getParameters() {
       return Arrays.asList(new Object[][]{
-         {TransportConstants.DEFAULT_KEYSTORE_PROVIDER, TransportConstants.DEFAULT_KEYSTORE_TYPE},
-         {"SunJCE", "JCEKS"},
-         {"SUN", "JKS"},
-         {"SunJSSE", "PKCS12"}
+         {TransportConstants.DEFAULT_KEYSTORE_PROVIDER, TransportConstants.DEFAULT_KEYSTORE_TYPE, false},
+         {"SunJCE", "JCEKS", false},
+         {"SUN", "JKS", false},
+         {"SunJSSE", "PKCS12", false},
+         {"JCEKS", null, true}, // for compatibility with old keyStoreProvider
+         {"JKS", null, true},   // for compatibility with old keyStoreProvider
+         {"PKCS12", null, true} // for compatibility with old keyStoreProvider
       });
    }
 
-   public CoreClientOverOneWaySSLTest(String storeProvider, String storeType) {
+   public CoreClientOverOneWaySSLTest(String storeProvider, String storeType, boolean generateWarning) {
       this.storeProvider = storeProvider;
       this.storeType = storeType;
-      suffix = storeType.toLowerCase();
+      this.generateWarning = generateWarning;
+      suffix = storeType == null || storeType.length() == 0 ? storeProvider.toLowerCase() : storeType.toLowerCase();
       // keytool expects PKCS12 stores to use the extension "p12"
-      if (storeType.equals("PKCS12")) {
+      if (suffix.equalsIgnoreCase("PKCS12")) {
          suffix = "p12";
       }
       SERVER_SIDE_KEYSTORE = "server-side-keystore." + suffix;
@@ -123,6 +130,7 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
     * keytool -export -keystore verified-server-side-keystore.p12 -file activemq-p12.cer -storetype PKCS12 -storepass secureexample
     * keytool -import -keystore verified-client-side-truststore.p12 -storetype PKCS12 -file activemq-p12.cer -storepass secureexample -keypass secureexample -noprompt
     */
+   private boolean generateWarning;
    private String storeProvider;
    private String storeType;
    private String SERVER_SIDE_KEYSTORE;
@@ -132,6 +140,21 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
    private ActiveMQServer server;
 
    private TransportConfiguration tc;
+
+   @Before
+   public void validateLogging() {
+      AssertionLoggerHandler.startCapture();
+   }
+
+   @After
+   public void afterValidateLogging() {
+      if (this.generateWarning) {
+         Assert.assertTrue(AssertionLoggerHandler.findText("AMQ212080"));
+      } else {
+         Assert.assertFalse(AssertionLoggerHandler.findText("AMQ212080"));
+      }
+      AssertionLoggerHandler.clear();
+   }
 
    @Test
    public void testOneWaySSL() throws Exception {
@@ -324,10 +347,10 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
       String text = RandomUtil.randomString();
 
       String url = "tcp://127.0.0.1:61616?sslEnabled=true;trustStorePath=" + CLIENT_SIDE_TRUSTSTORE + ";trustStorePassword=" + PASSWORD;
-      if (!storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
+      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
          url += ";trustStoreProvider=" + storeProvider;
       }
-      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
+      if (storeType != null && !storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
          url += ";trustStoreType=" + storeType;
       }
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocator(url));
@@ -359,10 +382,10 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
 
       String masked = codec.encode(PASSWORD);
       String url = "tcp://127.0.0.1:61616?sslEnabled=true;trustStorePath=" + CLIENT_SIDE_TRUSTSTORE + ";trustStorePassword=" + masked + ";activemq.usemaskedpassword=true";
-      if (!storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
+      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
          url += ";trustStoreProvider=" + storeProvider;
       }
-      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
+      if (storeType != null && !storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
          url += ";trustStoreType=" + storeType;
       }
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocator(url));
@@ -394,10 +417,10 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
       String masked = codec.encode(PASSWORD);
 
       String url = "tcp://127.0.0.1:61616?sslEnabled=true;trustStorePath=" + CLIENT_SIDE_TRUSTSTORE + ";trustStorePassword=ENC(" + masked + ")";
-      if (!storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
+      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
          url += ";trustStoreProvider=" + storeProvider;
       }
-      if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER)) {
+      if (storeType != null && !storeType.equals(TransportConstants.DEFAULT_TRUSTSTORE_TYPE)) {
          url += ";trustStoreType=" + storeType;
       }
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocator(url));
@@ -426,9 +449,10 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
       tc.getParams().put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
       tc.getParams().put(TransportConstants.USE_DEFAULT_SSL_CONTEXT_PROP_NAME, true);
 
+      Pair<String, String> compat = SSLSupport.getValidProviderAndType(storeProvider, storeType);
       SSLContext.setDefault(new SSLSupport()
-                               .setTruststoreProvider(storeProvider)
-                               .setTruststoreType(storeType)
+                               .setTruststoreProvider(compat.getA())
+                               .setTruststoreType(compat.getB())
                                .setTruststorePath(CLIENT_SIDE_TRUSTSTORE)
                                .setTruststorePassword(PASSWORD)
                                .createContext());
@@ -777,7 +801,7 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
       tc.getParams().put(TransportConstants.TRUSTSTORE_TYPE_PROP_NAME, storeType);
       tc.getParams().put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME, CLIENT_SIDE_TRUSTSTORE);
       tc.getParams().put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, PASSWORD);
-      tc.getParams().put(TransportConstants.ENABLED_PROTOCOLS_PROP_NAME, "TLSv1");
+      tc.getParams().put(TransportConstants.ENABLED_PROTOCOLS_PROP_NAME, "TLSv1.2");
 
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(tc));
       ClientSessionFactory sf = null;
@@ -805,7 +829,7 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
 
    @Test
    public void testOneWaySSLWithGoodServerProtocol() throws Exception {
-      createCustomSslServer(null, "TLSv1");
+      createCustomSslServer(null, "TLSv1.2");
       String text = RandomUtil.randomString();
 
       tc.getParams().put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
@@ -857,7 +881,8 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
        */
       for (int i = 0; i < suites.length; i++) {
          String suite = suites[i];
-         if ((storeType.equals("JCEKS") && suite.contains("RSA") && !suite.contains("ECDH_")) || (!storeType.equals("JCEKS") && !suite.contains("ECDSA") && suite.contains("RSA"))) {
+         String storeType = SSLSupport.getValidProviderAndType(this.storeProvider, this.storeType).getB();
+         if (storeType != null && ((storeType.equals("JCEKS") && suite.contains("RSA") && !suite.contains("ECDH_")) || (!storeType.equals("JCEKS") && !suite.contains("ECDSA") && suite.contains("RSA")))) {
             result = suite;
             break;
          }
@@ -867,13 +892,14 @@ public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase {
    }
 
    public String[] getEnabledCipherSuites() throws Exception {
+      Pair<String, String> compat = SSLSupport.getValidProviderAndType(storeProvider, storeType);
       SSLContext context = new SSLSupport()
-         .setKeystoreProvider(storeProvider)
-         .setKeystoreType(storeType)
+         .setKeystoreProvider(compat.getA())
+         .setKeystoreType(compat.getB())
          .setKeystorePath(SERVER_SIDE_KEYSTORE)
          .setKeystorePassword(PASSWORD)
-         .setTruststoreProvider(storeProvider)
-         .setTruststoreType(storeType)
+         .setTruststoreProvider(compat.getA())
+         .setTruststoreType(compat.getB())
          .setTruststorePath(CLIENT_SIDE_TRUSTSTORE)
          .setTruststorePassword(PASSWORD)
          .createContext();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverTwoWaySSLTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverTwoWaySSLTest.java
@@ -76,7 +76,11 @@ public class CoreClientOverTwoWaySSLTest extends ActiveMQTestBase {
          {"SunJSSE", "PKCS12", TransportConstants.OPENSSL_PROVIDER, TransportConstants.OPENSSL_PROVIDER},
          {"SunJSSE", "PKCS12", TransportConstants.OPENSSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER},
          {"SunJSSE", "PKCS12", TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.OPENSSL_PROVIDER},
-         {"SunJSSE", "PKCS12", TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER}
+         {"SunJSSE", "PKCS12", TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER},
+         {TransportConstants.DEFAULT_KEYSTORE_TYPE, null, TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER},
+         {"JCEKS", null, TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER},
+         {"JKS", null, TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER},
+         {"PKCS12", null, TransportConstants.DEFAULT_SSL_PROVIDER, TransportConstants.DEFAULT_SSL_PROVIDER}
       });
    }
 
@@ -86,9 +90,9 @@ public class CoreClientOverTwoWaySSLTest extends ActiveMQTestBase {
       this.clientSSLProvider = clientSSLProvider;
       this.serverSSLProvider = serverSSLProvider;
 
-      String suffix = storeType.toLowerCase();
+      String suffix = storeType == null || storeType.length() == 0 ? storeProvider.toLowerCase() : storeType.toLowerCase();
       // keytool expects PKCS12 stores to use the extension "p12"
-      if (storeType.equals("PKCS12")) {
+      if (suffix.equalsIgnoreCase("PKCS12")) {
          suffix = "p12";
       }
 
@@ -364,7 +368,7 @@ public class CoreClientOverTwoWaySSLTest extends ActiveMQTestBase {
       if (storeProvider != null && !storeProvider.equals(TransportConstants.DEFAULT_KEYSTORE_PROVIDER)) {
          uri.append("&").append(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME).append("=").append(storeProvider);
       }
-      if (!storeType.equals(TransportConstants.DEFAULT_KEYSTORE_TYPE)) {
+      if (storeType != null && !storeType.equals(TransportConstants.DEFAULT_KEYSTORE_TYPE)) {
          uri.append("&").append(TransportConstants.KEYSTORE_TYPE_PROP_NAME).append("=").append(storeType);
       }
       uri.append("&").append(TransportConstants.KEYSTORE_PATH_PROP_NAME).append("=").append(CLIENT_SIDE_KEYSTORE);


### PR DESCRIPTION
Support better backwards compability for SSL keyStoreProvider and
trustStoreProvider.

(cherry picked from commit 867bf5e01e010ae8d590ac9469778ad6786803cb)

downstream: ENTMQBR-4619