### PR TITLE
[ARTEMIS-3431]: PrintData is missing a retro-compatible method.

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -124,6 +124,10 @@ public class PrintData extends DBOption {
       printData(bindingsDirectory, messagesDirectory, pagingDirectory, System.out, secret, false);
    }
 
+   public static void printData(File bindingsDirectory, File messagesDirectory, File pagingDirectory, PrintStream out, boolean secret) throws Exception {
+      printData(bindingsDirectory, messagesDirectory, pagingDirectory, out, secret, false);
+   }
+
    public static void printData(File bindingsDirectory, File messagesDirectory, File pagingDirectory, PrintStream out, boolean safe, boolean reclaimed) throws Exception {
       // printing the banner and version
       Artemis.printBanner(out);


### PR DESCRIPTION
 * Adding public static void printData(File bindingsDirectory, File messagesDirectory, File pagingDirectory, PrintStream out, boolean secret) throws Exception

Issue: https://issues.apache.org/jira/browse/ARTEMIS-3431
(cherry picked from commit 2f74fa192059acf7a9f0f570a0eca4eb9df669aa)

downstream: ENTMQBR-5365