### PR TITLE
ARTEMIS-3395 ensure sending audit log contains message ID

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1777,10 +1777,6 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                                           final boolean direct,
                                           boolean noAutoCreateQueue,
                                           RoutingContext routingContext) throws Exception {
-      if (AuditLogger.isMessageEnabled()) {
-         AuditLogger.coreSendMessage(getUsername(), messageParameter.toString(), routingContext);
-      }
-
       final Message message = LargeServerMessageImpl.checkLargeMessage(messageParameter, storageManager);
 
       if (server.hasBrokerMessagePlugins()) {
@@ -1804,6 +1800,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
             long id = storageManager.generateID();
             // This will re-encode the message
             message.setMessageID(id);
+         }
+
+         if (AuditLogger.isMessageEnabled()) {
+            AuditLogger.coreSendMessage(getUsername(), message.toString(), routingContext);
          }
 
          SimpleString address = message.getAddressSimpleString();

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
@@ -207,6 +207,7 @@ public class AuditLoggerTest extends SmokeTestBase {
          Wait.waitFor(() -> addressControl.getMessageCount() == 2);
          Assert.assertEquals(2, addressControl.getMessageCount());
 
+         checkAuditLogRecord(false, "messageID=0");
          checkAuditLogRecord(true, "sending a message");
          checkAuditLogRecord(true, uniqueStr);
          checkAuditLogRecord(true, "Hello2");


### PR DESCRIPTION
(cherry picked from commit bb9bbf062da0d6c146a5f40ee4af5e5a6c6997a6)

downstream: ENTMQBR-5280