### PR TITLE
ARTEMIS-3385 management changes can be reverted by XML update

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3545,17 +3545,22 @@ public class ActiveMQServerImpl implements ActiveMQServer {
     * @throws Exception
     */
    private void recoverStoredConfigs() throws Exception {
+      recoverStoredAddressSettings();
+      recoverStoredSecuritySettings();
+   }
+
+   private void recoverStoredSecuritySettings() throws Exception {
+      List<PersistedSecuritySetting> roles = storageManager.recoverSecuritySettings();
+      for (PersistedSecuritySetting roleItem : roles) {
+         Set<Role> setRoles = SecurityFormatter.createSecurity(roleItem.getSendRoles(), roleItem.getConsumeRoles(), roleItem.getCreateDurableQueueRoles(), roleItem.getDeleteDurableQueueRoles(), roleItem.getCreateNonDurableQueueRoles(), roleItem.getDeleteNonDurableQueueRoles(), roleItem.getManageRoles(), roleItem.getBrowseRoles(), roleItem.getCreateAddressRoles(), roleItem.getDeleteAddressRoles());
+         securityRepository.addMatch(roleItem.getAddressMatch().toString(), setRoles);
+      }
+   }
+
+   private void recoverStoredAddressSettings() throws Exception {
       List<PersistedAddressSetting> adsettings = storageManager.recoverAddressSettings();
       for (PersistedAddressSetting set : adsettings) {
          addressSettingsRepository.addMatch(set.getAddressMatch().toString(), set.getSetting());
-      }
-
-      List<PersistedSecuritySetting> roles = storageManager.recoverSecuritySettings();
-
-      for (PersistedSecuritySetting roleItem : roles) {
-         Set<Role> setRoles = SecurityFormatter.createSecurity(roleItem.getSendRoles(), roleItem.getConsumeRoles(), roleItem.getCreateDurableQueueRoles(), roleItem.getDeleteDurableQueueRoles(), roleItem.getCreateNonDurableQueueRoles(), roleItem.getDeleteNonDurableQueueRoles(), roleItem.getManageRoles(), roleItem.getBrowseRoles(), roleItem.getCreateAddressRoles(), roleItem.getDeleteAddressRoles());
-
-         securityRepository.addMatch(roleItem.getAddressMatch().toString(), setRoles);
       }
    }
 
@@ -4019,6 +4024,14 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    private void deployDiverts() throws Exception {
+      recoverStoredDiverts();
+      //deploy the configured diverts
+      for (DivertConfiguration config : configuration.getDivertConfigurations()) {
+         deployDivert(config);
+      }
+   }
+
+   private void recoverStoredDiverts() throws Exception {
       if (storageManager.recoverDivertConfigurations() != null) {
          for (PersistedDivertConfiguration persistedDivertConfiguration : storageManager.recoverDivertConfigurations()) {
             boolean deleted = true;
@@ -4033,9 +4046,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                deployDivert(persistedDivertConfiguration.getDivertConfiguration());
             }
          }
-      }
-      for (DivertConfiguration config : configuration.getDivertConfigurations()) {
-         deployDivert(config);
       }
    }
 
@@ -4269,9 +4279,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       if (configurationReloadDeployed.compareAndSet(false, true)) {
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("security");
          securityRepository.swap(configuration.getSecurityRoles().entrySet());
+         recoverStoredSecuritySettings();
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("address settings");
          addressSettingsRepository.swap(configuration.getAddressesSettings().entrySet());
+         recoverStoredAddressSettings();
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("diverts");
          final Set<SimpleString> divertsToRemove = postOffice.getAllBindings()
@@ -4291,6 +4303,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                logger.warn("Divert " + divertName + " could not be removed", e);
             }
          }
+         recoverStoredDiverts();
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("addresses");
          undeployAddressesAndQueueNotInConfiguration(configuration);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -198,6 +198,237 @@ public class RedeployTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testRedeploySecuritySettings() throws Exception {
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      URL url1 = RedeployTest.class.getClassLoader().getResource("reload-security-settings.xml");
+      URL url2 = RedeployTest.class.getClassLoader().getResource("reload-security-settings-updated.xml");
+      Files.copy(url1.openStream(), brokerXML);
+
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      final ReusableLatch latch = new ReusableLatch(1);
+
+      Runnable tick = new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      };
+
+      embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+
+      try {
+         latch.await(10, TimeUnit.SECONDS);
+
+         Set<Role> roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("foo");
+         boolean found = false;
+         for (Role role : roles) {
+            if (role.getName().equals("a")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+         Files.copy(url2.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+         brokerXML.toFile().setLastModified(System.currentTimeMillis() + 1000);
+         latch.setCount(1);
+         embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+         latch.await(10, TimeUnit.SECONDS);
+
+         roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("foo");
+         found = false;
+         for (Role role : roles) {
+            if (role.getName().equals("b")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   @Test
+   public void testRedeploySecuritySettingsWithManagementChange() throws Exception {
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      URL url1 = RedeployTest.class.getClassLoader().getResource("reload-security-settings.xml");
+      URL url2 = RedeployTest.class.getClassLoader().getResource("reload-security-settings-updated.xml");
+      Files.copy(url1.openStream(), brokerXML);
+
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      final ReusableLatch latch = new ReusableLatch(1);
+
+      Runnable tick = new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      };
+
+      embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+
+      try {
+         latch.await(10, TimeUnit.SECONDS);
+
+         Set<Role> roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("foo");
+         boolean found = false;
+         for (Role role : roles) {
+            if (role.getName().equals("a")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+         embeddedActiveMQ.getActiveMQServer().getActiveMQServerControl().addSecuritySettings("bar", "c", "c", "c", "c", "c", "c", "c", "c", "c", "c");
+         roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("bar");
+         for (Role role : roles) {
+            if (role.getName().equals("c")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+         Files.copy(url2.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+         brokerXML.toFile().setLastModified(System.currentTimeMillis() + 1000);
+         latch.setCount(1);
+         embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+         latch.await(10, TimeUnit.SECONDS);
+
+         roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("foo");
+         found = false;
+         for (Role role : roles) {
+            if (role.getName().equals("b")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+         roles = embeddedActiveMQ.getActiveMQServer().getSecurityRepository().getMatch("bar");
+         found = false;
+         for (Role role : roles) {
+            if (role.getName().equals("c")) {
+               found = true;
+            }
+         }
+
+         assertTrue(found);
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   @Test
+   public void testRedeployAddressSettingsWithManagementChange() throws Exception {
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      URL url1 = RedeployTest.class.getClassLoader().getResource("reload-address-settings.xml");
+      URL url2 = RedeployTest.class.getClassLoader().getResource("reload-address-settings-updated.xml");
+      Files.copy(url1.openStream(), brokerXML);
+
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      final ReusableLatch latch = new ReusableLatch(1);
+
+      Runnable tick = new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      };
+
+      embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+
+      try {
+         latch.await(10, TimeUnit.SECONDS);
+
+         AddressSettings addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("foo");
+         assertEquals("a", addressSettings.getDeadLetterAddress().toString());
+
+         embeddedActiveMQ.getActiveMQServer().getActiveMQServerControl().addAddressSettings("bar", "c", null, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, false, null, 0, 0, null, false, false, false, false);
+         addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("bar");
+         assertEquals("c", addressSettings.getDeadLetterAddress().toString());
+
+         Files.copy(url2.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+         brokerXML.toFile().setLastModified(System.currentTimeMillis() + 1000);
+         latch.setCount(1);
+         embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+         latch.await(10, TimeUnit.SECONDS);
+
+         addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("foo");
+         assertEquals("b", addressSettings.getDeadLetterAddress().toString());
+
+         addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("bar");
+         assertEquals("c", addressSettings.getDeadLetterAddress().toString());
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   @Test
+   public void testRedeployDivertsWithManagementChange() throws Exception {
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      URL url1 = RedeployTest.class.getClassLoader().getResource("reload-diverts.xml");
+      URL url2 = RedeployTest.class.getClassLoader().getResource("reload-diverts-updated.xml");
+      Files.copy(url1.openStream(), brokerXML);
+
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      final ReusableLatch latch = new ReusableLatch(1);
+
+      Runnable tick = new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      };
+
+      embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+
+      try {
+         latch.await(10, TimeUnit.SECONDS);
+
+         DivertBinding divertBinding = (DivertBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice().getBinding(new SimpleString("a"));
+         assertNotNull(divertBinding);
+         assertEquals("a", divertBinding.getDivert().getAddress().toString());
+
+         embeddedActiveMQ.getActiveMQServer().getActiveMQServerControl().createDivert("c", "c", "c", "target", false, null, null);
+
+         Files.copy(url2.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+         brokerXML.toFile().setLastModified(System.currentTimeMillis() + 1000);
+         latch.setCount(1);
+         embeddedActiveMQ.getActiveMQServer().getReloadManager().setTick(tick);
+         latch.await(10, TimeUnit.SECONDS);
+
+         divertBinding = (DivertBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice().getBinding(new SimpleString("b"));
+         assertNotNull(divertBinding);
+         assertEquals("b", divertBinding.getDivert().getAddress().toString());
+
+         divertBinding = (DivertBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice().getBinding(new SimpleString("c"));
+         assertNotNull(divertBinding);
+         assertEquals("c", divertBinding.getDivert().getAddress().toString());
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   @Test
    public void testRedeployFilter() throws Exception {
       Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
       URL url1 = RedeployTest.class.getClassLoader().getResource("reload-queue-filter.xml");

--- a/tests/integration-tests/src/test/resources/reload-address-settings-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-settings-updated.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <!-- this could be ASYNCIO or NIO
+       -->
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="foo">
+            <dead-letter-address>b</dead-letter-address>
+         </address-setting>
+      </address-settings>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-address-settings.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-settings.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <!-- this could be ASYNCIO or NIO
+       -->
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="foo">
+            <dead-letter-address>a</dead-letter-address>
+         </address-setting>
+      </address-settings>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-diverts-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-diverts-updated.xml
@@ -1,0 +1,64 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="a"/>
+         <address name="b"/>
+         <address name="c"/>
+         <address name="target"/>
+      </addresses>
+
+      <diverts>
+         <divert name="b">
+            <address>b</address>
+            <forwarding-address>target</forwarding-address>
+         </divert>
+      </diverts>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-diverts.xml
+++ b/tests/integration-tests/src/test/resources/reload-diverts.xml
@@ -1,0 +1,64 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="a"/>
+         <address name="b"/>
+         <address name="c"/>
+         <address name="target"/>
+      </addresses>
+
+      <diverts>
+         <divert name="a">
+            <address>a</address>
+            <forwarding-address>target</forwarding-address>
+         </divert>
+      </diverts>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-security-settings-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-security-settings-updated.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="foo">
+            <permission type="createNonDurableQueue" roles="b"/>
+            <permission type="deleteNonDurableQueue" roles="b"/>
+            <permission type="createDurableQueue" roles="b"/>
+            <permission type="deleteDurableQueue" roles="b"/>
+            <permission type="browse" roles="b"/>
+            <permission type="send" roles="b"/>
+            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+            <permission type="manage" roles="b"/>
+         </security-setting>
+      </security-settings>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-security-settings.xml
+++ b/tests/integration-tests/src/test/resources/reload-security-settings.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./target/data/paging</paging-directory>
+
+      <bindings-directory>./target/data/bindings</bindings-directory>
+
+      <journal-directory>./target/data/journal</journal-directory>
+
+      <large-messages-directory>./target/data/large-messages</large-messages-directory>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="foo">
+            <permission type="createNonDurableQueue" roles="a"/>
+            <permission type="deleteNonDurableQueue" roles="a"/>
+            <permission type="createDurableQueue" roles="a"/>
+            <permission type="deleteDurableQueue" roles="a"/>
+            <permission type="browse" roles="a"/>
+            <permission type="send" roles="a"/>
+            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+            <permission type="manage" roles="a"/>
+         </security-setting>
+      </security-settings>
+   </core>
+</configuration>


### PR DESCRIPTION
Durable changes made via the management API (e.g. adding
security-settings, adding address-settings, adding diverts) can be
reverted when reloading the XML at runtime.

(cherry picked from commit 6bd30e8fe34066fa02ff253e4f71781cc12c2278)

downstream: ENTMQBR-5207