### PR TITLE
ARTEMIS-3457 log WARN for OpenWire property conversion problem

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverterTest.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverterTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class OpenWireMessageConverterTest {
@@ -107,5 +108,30 @@ public class OpenWireMessageConverterTest {
       MessageDispatch messageDispatch = OpenWireMessageConverter.createMessageDispatch(messageReference, coreMessage, openWireFormat, amqConsumer, nodeUUID);
 
       assertTrue(messageDispatch.getMessage().getProperty(bytesPropertyKey) instanceof String);
+   }
+
+   @Test
+   public void testBadPropertyConversion() throws Exception {
+      final String hdrArrival = "__HDR_ARRIVAL";
+      final String hdrBrokerInTime = "__HDR_BROKER_IN_TIME";
+      final String hdrCommandId = "__HDR_COMMAND_ID";
+      final String hdrDroppable = "__HDR_DROPPABLE";
+
+      ICoreMessage coreMessage = new CoreMessage().initBuffer(8);
+      coreMessage.putStringProperty(hdrArrival, "1234");
+      coreMessage.putStringProperty(hdrBrokerInTime, "5678");
+      coreMessage.putStringProperty(hdrCommandId, "foo");
+      coreMessage.putStringProperty(hdrDroppable, "true");
+
+      MessageReference messageReference = new MessageReferenceImpl(coreMessage, Mockito.mock(Queue.class), null);
+      AMQConsumer amqConsumer = Mockito.mock(AMQConsumer.class);
+      Mockito.when(amqConsumer.getOpenwireDestination()).thenReturn(destination);
+
+      MessageDispatch messageDispatch = OpenWireMessageConverter.createMessageDispatch(messageReference, coreMessage, openWireFormat, amqConsumer, nodeUUID);
+
+      assertNull(messageDispatch.getMessage().getProperty(hdrArrival));
+      assertNull(messageDispatch.getMessage().getProperty(hdrBrokerInTime));
+      assertNull(messageDispatch.getMessage().getProperty(hdrCommandId));
+      assertNull(messageDispatch.getMessage().getProperty(hdrDroppable));
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1736,6 +1736,10 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void gettingSslHandlerFailed(String clientAddress, String cause);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222302, value = "Failed to deal with property {0} when converting message from core to OpenWire: {1}", format = Message.Format.MESSAGE_FORMAT)
+   void failedToDealWithObjectProperty(SimpleString property, String exceptionMessage);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);


### PR DESCRIPTION
While converting a core message to an OpenWire message there may be an
error processing a property value. Currently this results in an
exception and the message is not dispatched to the client. The broker
eventually attempts to redeliver this message resulting in the same
error. Instead of throwing an exception the broker should simply log a
WARN message and skip the property. This will allow clients to receive
the message without the problematic property and the broker will not
have to attempt to redeliver the message again.

(cherry picked from commit 13df6a8fb9522e53d875755be1d217ab3e260d65)

downstream: ENTMQBR-5465