### PR TITLE
ARTEMIS-3472 Reconnect openwire could leave Openwire internal session null

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -774,7 +774,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
    }
 
    //raise the refCount of context
-   public void reconnect(AMQConnectionContext existingContext, ConnectionInfo info) {
+   public void reconnect(AMQConnectionContext existingContext, ConnectionInfo info) throws Exception {
       this.context = existingContext;
       WireFormatInfo wireFormatInfo = inWireFormat.getPreferedWireFormatInfo();
       // Older clients should have been defaulting this field to true.. but
@@ -785,7 +785,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
       if (info.getClientIp() == null) {
          info.setClientIp(getRemoteAddress());
       }
-
+      createInternalSession(info);
       state = new ConnectionState(info);
       state.reset(info);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ReconnectFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ReconnectFailoverTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.openwire.amq;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.tests.integration.openwire.BasicOpenWireTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReconnectFailoverTest extends BasicOpenWireTest {
+
+   @Test
+   public void testReconnectOnFailoverWithClientID() throws Exception {
+      ConnectionFactory failoverFactory = new ActiveMQConnectionFactory("failover:(tcp://localhost:61616)");
+      Connection connection = failoverFactory.createConnection();
+      try {
+         connection.setClientID("foo");
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         server.getRemotingService().getConnections().forEach(c -> c.getTransportConnection().forceClose());
+         Queue tempQueue = session.createTemporaryQueue();
+         MessageProducer producer = session.createProducer(tempQueue);
+         for (int i = 0; i < 10; i++) {
+            producer.send(session.createTextMessage("hello"));
+         }
+         connection.start();
+         MessageConsumer consumer = session.createConsumer(tempQueue);
+         for (int i = 0; i < 10; i++) {
+            TextMessage message = (TextMessage) consumer.receive(1000);
+            Assert.assertNotNull(message);
+            Assert.assertEquals("hello", message.getText());
+         }
+      } finally {
+         connection.close();
+      }
+   }
+
+}


### PR DESCRIPTION
(cherry picked from commit 43ca9540bedc9340eacc2e3d4abd7f667c1ef4d1)

downstream: ENTMQBR-5400