### PR TITLE
ARTEMIS-3457 Dealing with String conversions

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -710,7 +710,12 @@ public final class OpenWireMessageConverter {
    private static <T> T getObjectProperty(ICoreMessage message, Class<T> type, SimpleString property) {
       if (message.getPropertyNames().contains(property)) {
          try {
-            return type.cast(message.getObjectProperty(property));
+            Object value = message.getObjectProperty(property);
+            if (type == String.class && value != null) {
+               return (T)value.toString();
+            } else {
+               return type.cast(value);
+            }
          } catch (ClassCastException e) {
             ActiveMQServerLogger.LOGGER.failedToDealWithObjectProperty(property, e.getMessage());
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/CompactingOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/CompactingOpenWireTest.java
@@ -153,6 +153,7 @@ public class CompactingOpenWireTest extends BasicOpenWireTest {
          Assert.assertEquals(0, errors.get());
          Assert.assertFalse(AssertionLoggerHandler.findText("AMQ144003")); // error compacting
          Assert.assertFalse(AssertionLoggerHandler.findText("AMQ222055")); // records not found
+         Assert.assertFalse(AssertionLoggerHandler.findText("AMQ222302")); // string conversion issue
       } finally {
          AssertionLoggerHandler.stopCapture();
          running.set(false);


### PR DESCRIPTION
The test I wrote for ARTEMIS-3513 is throwing a few convert exceptions
because of SimpleString versus String conversion

This commit is addressing the issue,
The previous commit (the one addressing ARTEMIS-3513) should provide the test for this change.

(cherry picked from commit 557506140fa2bb2df68b6a1905b201c84da811ed)

downstream: ENTMQBR-4894