### PR TITLE
ARTEMIS-3581 - allow max-size-bytes=0 configuration force paging for …

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -166,15 +166,6 @@ public class PagingStoreImpl implements PagingStore {
 
       applySetting(addressSettings);
 
-      if (addressFullMessagePolicy == AddressFullMessagePolicy.PAGE && maxSize != -1 && pageSize >= maxSize) {
-         throw new IllegalStateException("pageSize for address " + address +
-                                            " >= maxSize. Normally pageSize should" +
-                                            " be significantly smaller than maxSize, ms: " +
-                                            maxSize +
-                                            " ps " +
-                                            pageSize);
-      }
-
       this.executor = executor;
 
       this.pagingManager = pagingManager;
@@ -259,8 +250,8 @@ public class PagingStoreImpl implements PagingStore {
 
    @Override
    public long getMaxSize() {
-      if (maxSize < 0) {
-         // if maxSize < 0, we will return 2 pages for depage purposes
+      if (maxSize <= 0) {
+         // if maxSize <= 0, we will return 2 pages for de-page purposes
          return pageSize * 2;
       } else {
          return maxSize;

--- a/docs/user-manual/en/paging.md
+++ b/docs/user-manual/en/paging.md
@@ -53,14 +53,15 @@ You can configure the location of the paging folder in `broker.xml`.
 ## Paging Mode
 
 As soon as messages delivered to an address exceed the configured size,
-that address alone goes into page mode.
+that address alone goes into page mode. If max-size-bytes == 0, an address
+will immediately enter into page mode.
 
 > **Note:**
 >
 > Paging is done individually per address. If you configure a max-size-bytes
 > for an address, that means each matching address will have a maximum size
 > that you specified. It DOES NOT mean that the total overall size of all
-> matching addresses is limited to max-size-bytes.
+> matching addresses is limited to max-size-bytes. Use [global-max-size](#global-max-size) for that!
 
 ### Configuration
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -4648,7 +4648,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       addresses.put("#", new AddressSettings());
 
-      AddressSettings pagedDestination = new AddressSettings().setPageSizeBytes(1024).setMaxSizeBytes(10 * 1024);
+      AddressSettings pagedDestination = new AddressSettings().setPageSizeBytes(1024).setMaxSizeBytes(0);
 
       addresses.put(PAGED_ADDRESS.toString(), pagedDestination);
 


### PR DESCRIPTION
…an address, independent of the page-size-bytes

(cherry picked from commit 8d50aa916c0cfff2540a8614dba52015144e882e)

downstream: ENTMQBR-5965