### PR TITLE
ARTEMIS-3541 createQueue ignoring autoDeleteAddress flag

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1068,7 +1068,7 @@ public interface ActiveMQServerControl {
    @Operation(desc = "Destroy a queue", impact = MBeanOperationInfo.ACTION)
    void destroyQueue(@Parameter(name = "name", desc = "Name of the queue to destroy") String name,
                      @Parameter(name = "removeConsumers", desc = "Remove consumers of this queue") boolean removeConsumers,
-                     @Parameter(name = "autoDeleteAddress", desc = "Automatically delete the address if this was the last queue") boolean autoDeleteAddress) throws Exception;
+                     @Parameter(name = "forceAutoDeleteAddress", desc = "Automatically delete the address if this was the last queue") boolean autoDeleteAddress) throws Exception;
 
    /**
     * Enables message counters for this server.

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -817,7 +817,7 @@ public class JMSServerManagerImpl extends CleaningActivateCallback implements JM
 
             // We can't remove the remote binding. As this would be the bridge associated with the topic on this case
             if (binding.getType() != BindingType.REMOTE_QUEUE) {
-               server.destroyQueue(SimpleString.toSimpleString(queueName), null, !removeConsumers, removeConsumers, true);
+               server.destroyQueue(SimpleString.toSimpleString(queueName), null, !removeConsumers, removeConsumers, false);
             }
          }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1529,9 +1529,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
-   public void destroyQueue(final String name, final boolean removeConsumers, final boolean autoDeleteAddress) throws Exception {
+   public void destroyQueue(final String name, final boolean removeConsumers, final boolean forceAutoDeleteAddress) throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
-         AuditLogger.destroyQueue(this.server, null, null, name, removeConsumers, autoDeleteAddress);
+         AuditLogger.destroyQueue(this.server, null, null, name, removeConsumers, forceAutoDeleteAddress);
       }
       checkStarted();
 
@@ -1539,7 +1539,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       try {
          SimpleString queueName = new SimpleString(name);
          try {
-            server.destroyQueue(queueName, null, !removeConsumers, removeConsumers, autoDeleteAddress);
+            server.destroyQueue(queueName, null, !removeConsumers, removeConsumers, forceAutoDeleteAddress);
          } catch (Exception e) {
             if (AuditLogger.isResourceLoggingEnabled()) {
                AuditLogger.destroyQueueFailure(name);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -671,13 +671,13 @@ public interface ActiveMQServer extends ServiceComponent {
                      SecurityAuth session,
                      boolean checkConsumerCount,
                      boolean removeConsumers,
-                     boolean autoDeleteAddress) throws Exception;
+                     boolean forceAutoDeleteAddress) throws Exception;
 
    void destroyQueue(SimpleString queueName,
                      SecurityAuth session,
                      boolean checkConsumerCount,
                      boolean removeConsumers,
-                     boolean autoDeleteAddress,
+                     boolean forceAutoDeleteAddress,
                      boolean checkMessageCount) throws Exception;
 
    String destroyConnectionWithSessionMetadata(String metaKey, String metaValue) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueManagerImpl.java
@@ -72,7 +72,7 @@ public class QueueManagerImpl extends ReferenceCounterUtil implements QueueManag
       ActiveMQServerLogger.LOGGER.autoRemoveQueue("" + queue.getName(), queue.getID(), "" + queue.getAddress());
 
       try {
-         server.destroyQueue(queueName, null, true, false, settings.isAutoDeleteAddresses(), true);
+         server.destroyQueue(queueName, null, true, false, false, true);
       } catch (Exception e) {
          ActiveMQServerLogger.LOGGER.errorRemovingAutoCreatedDestination(e, queueName, "queue");
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1129,7 +1129,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                logger.debug("deleting temporary queue " + bindingName);
             }
             try {
-               server.destroyQueue(bindingName, null, false);
+               server.destroyQueue(bindingName, null, false, false, true);
                if (observer != null) {
                   observer.tempQueueDeleted(bindingName);
                }
@@ -1177,7 +1177,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          throw new ActiveMQNonExistentQueueException();
       }
 
-      server.destroyQueue(unPrefixedQueueName, this, true);
+      server.destroyQueue(unPrefixedQueueName, this, true, false, true);
 
       TempQueueCleanerUpper cleaner = this.tempQueueCleannerUppers.remove(unPrefixedQueueName);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/TopicDurableTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/TopicDurableTests.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.junit.Test;
@@ -46,6 +47,11 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 
 public class TopicDurableTests extends JMSClientTestSupport {
+
+   @Override
+   protected void addConfiguration(ActiveMQServer server) {
+      server.getConfiguration().setAddressQueueScanPeriod(100);
+   }
 
    @Test
    public void testMessageDurableSubscription() throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -75,6 +75,7 @@ import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
@@ -496,6 +497,35 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(address.toString(), addressControl.getAddress());
 
       serverControl.destroyQueue(name.toString(), true, true);
+
+      checkNoResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
+      checkNoResource(ObjectNameBuilder.DEFAULT.getAddressObjectName(address));
+   }
+
+   @Test
+   public void testCreateAndDestroyQueueWithAutoDeleteAddress() throws Exception {
+      server.getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoDeleteAddresses(false));
+      SimpleString address = RandomUtil.randomSimpleString();
+      SimpleString name = RandomUtil.randomSimpleString();
+
+      ActiveMQServerControl serverControl = createManagementControl();
+
+      checkNoResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
+      if (legacyCreateQueue) {
+         serverControl.createQueue(address.toString(), "ANYCAST", name.toString(), null, true, -1, false, true);
+      } else {
+         serverControl.createQueue(new QueueConfiguration(name).setAddress(address).setRoutingType(RoutingType.ANYCAST).setAutoCreateAddress(true).toJSON());
+      }
+
+      checkResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
+      QueueControl queueControl = ManagementControlHelper.createQueueControl(address, name, RoutingType.ANYCAST, mbeanServer);
+      Assert.assertEquals(address.toString(), queueControl.getAddress());
+      Assert.assertEquals(name.toString(), queueControl.getName());
+      Assert.assertNull(queueControl.getFilter());
+      Assert.assertEquals(true, queueControl.isDurable());
+      Assert.assertEquals(false, queueControl.isTemporary());
+
+      serverControl.destroyQueue(name.toString(), false, true);
 
       checkNoResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
       checkNoResource(ObjectNameBuilder.DEFAULT.getAddressObjectName(address));


### PR DESCRIPTION
Commit 481b73c8cabf9d7c88bca048b97bd587661b9c52 from ARTEMIS-3502
inadvertently broke this functionality. This commit restores the
original behavior.

autoDeleteAddress was renamed to forceAutoDeleteAddress which will ignore the address settings.

delete temporary queues will use forceAutoDeleteAddress=true.

this is done in collaboration with Justin Bertram

(cherry picked from commit 1d0c0a889721980488a22a677147c5855612ccb2)

downstream: ENTMQBR-5576