### PR TITLE
ARTEMIS-3054 - fix lock inversion - intermittent failure of PageClean…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -631,12 +631,12 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
 
       try {
          Map<SimpleString, Collection<Integer>> pageFilesToSync;
-         storageManagerLock.writeLock().lock();
 
          // We need to get this lock here in order to
          // avoid a clash with Page.cleanup();
          // This was a fix part of https://issues.apache.org/jira/browse/ARTEMIS-3054
          pagingManager.lock();
+         storageManagerLock.writeLock().lock();
          try {
             if (isReplicated())
                throw new ActiveMQIllegalStateException("already replicating");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PageCleanupWhileReplicaCatchupTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PageCleanupWhileReplicaCatchupTest.java
@@ -80,7 +80,7 @@ public class PageCleanupWhileReplicaCatchupTest extends FailoverTestBase {
       return createInVMFailoverServer(realFiles, configuration, PAGE_SIZE, PAGE_MAX, conf, nodeManager, id);
    }
 
-   @Test(timeout = 120_000)
+   @Test(timeout = 160_000)
    public void testPageCleanup() throws Throwable {
       int numberOfWorkers = 20;
 


### PR DESCRIPTION
…upWhileReplicaCatchupTest and hang

(cherry picked from commit 56299e846afb223752a7595581433745ae342156)

downstream: ENTMQBR-4822