### PR TITLE
ARTEMIS-3811 Cluster connections clashing with ANYCast addresses

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -354,7 +354,7 @@ public class SimpleAddressManager implements AddressManager {
       final Bindings bindings = this.mappings.get(addressName);
       if (bindings != null) {
          for (Binding binding : bindings.getBindings()) {
-            if (binding instanceof QueueBinding) {
+            if (binding instanceof QueueBinding && binding.isLocal()) {
                final QueueBinding queueBinding = (QueueBinding) binding;
                final RoutingType routingType = queueBinding.getQueue().getRoutingType();
                if (!routingTypes.contains(routingType) && binding.getAddress().equals(addressName)) {


### PR DESCRIPTION
This is a test fix for AMQPClusterReplicaTest

(cherry picked from commit ee51a7806da5f258dbb1ed56271c56d3e992383b)

downstream: ENTMQBR-6617