### PR TITLE
ARTEMIS-3853 Fix default ping command IPv6 for Windows

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -50,7 +50,7 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
    private final Set<URL> urls = new ConcurrentHashSet<>();
    private NetworkInterface networkInterface;
 
-   public static final String IPV6_DEFAULT_COMMAND = "ping6 -c 1 %2$s";
+   public static final String IPV6_DEFAULT_COMMAND = Env.isWindowsOs() ? "ping -n 1 -w %d %s" : "ping6 -c 1 %2$s";
 
    public static final String IPV4_DEFAULT_COMMAND = Env.isMacOs() ? "ping -c 1 -t %d %s" : Env.isWindowsOs() ? "cmd /C ping -n 1 -w %d %s | findstr /i TTL" : "ping -c 1 -w %d %s";
 


### PR DESCRIPTION
(cherry picked from commit 8d27f3e333a346c9dfacc48d40c9fc60f77c4df5)

downstream: ENTMQBR-6719