### PR TITLE
[JBEAP-24526][ENTMQBR-7652] Fix unsupported logger.debug() SLF4J API …

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileLockNodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileLockNodeManager.java
@@ -212,7 +212,7 @@ public class FileLockNodeManager extends FileBasedNodeManager {
                // if the backup acquires the file lock and the state is 'L' that means the primary died
 	       logger.debug("acquired live node lock state = " + (char) state);
                serverLockFile.setLastModified(System.currentTimeMillis());
-               logger.debug("touched {}; new time: {}", serverLockFile.getAbsoluteFile(), serverLockFile.lastModified());
+               logger.debug("touched " + serverLockFile.getAbsoluteFile() + "; new time: " + serverLockFile.lastModified());
                break;
             }
          }
@@ -340,7 +340,7 @@ public class FileLockNodeManager extends FileBasedNodeManager {
             }
          }
          serverLockLastModified = serverLockFile.lastModified();
-         logger.debug("Modified {} at {}", serverLockFile.getName(), serverLockLastModified);
+         logger.debug("Modified " + serverLockFile.getName() + " at " + serverLockLastModified);
       } catch (IOException | ActiveMQLockAcquisitionTimeoutException e) {
          throw new NodeManagerException(e);
       }
@@ -418,7 +418,7 @@ public class FileLockNodeManager extends FileBasedNodeManager {
             FileLock lock = tryLock(lockPosition);
             isRecurringFailure = false;
 
-            logger.debug("lock: {}", lock);
+            logger.debug("lock: " + lock);
 
             // even if the lock is valid it may have taken too long to acquire
             if (this.lockAcquisitionTimeoutNanos != -1 && (System.nanoTime() - start) > this.lockAcquisitionTimeoutNanos) {
@@ -558,11 +558,11 @@ public class FileLockNodeManager extends FileBasedNodeManager {
          if (freshServerLockFile.exists()) {
             // the other broker competing for the lock may modify the state as 'F' when it starts so ensure the state is 'L' before returning true
             if (freshServerLockFile.lastModified() > serverLockLastModified && state == LIVE) {
-               logger.debug("Lock file {} originally locked at {} was modified at {}", serverLockFile.getAbsolutePath(), new Date(serverLockLastModified), new Date(freshServerLockFile.lastModified()));
+               logger.debug("Lock file " + serverLockFile.getAbsolutePath() + " originally locked at " + new Date(serverLockLastModified) + " was modified at " + new Date(freshServerLockFile.lastModified()));
                modified = true;
             }
          } else {
-            logger.debug("Lock file {} does not exist", serverLockFile.getAbsolutePath());
+            logger.debug("Lock file " + serverLockFile.getAbsolutePath() + " does not exist");
             modified = true;
          }
 


### PR DESCRIPTION
…cherry picked from upstream

[JBEAP-24526][ENTMQBR-7652] Fix unsupported logger.debug() SLF4J API cherry picked from upstream

JBEAP issue: https://issues.redhat.com/browse/JBEAP-24526
ENTMQBR issue: https://issues.redhat.com/browse/ENTMQBR-7652

Branch `2.16.0.jbossorg-eap-x` does not compile because https://github.com/rh-messaging/activemq-artemis/commit/58973058c8b8d9afab3b32e0cde1bcf1f357b70c introduced unsupported logger.debug() SLF4J API cherry picked from upstream