### PR TITLE
ARTEMIS-4283 Fail fast CORE client connect on closing

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
@@ -237,4 +237,7 @@ public interface ActiveMQClientMessageBundle {
 
    @Message(id = 219065, value = "Failed to handle packet.")
    RuntimeException failedToHandlePacket(@Cause Exception e);
+
+   @Message(id = 219068, value = "Connection closed while receiving cluster topology. Group:{0}", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQObjectClosedException connectionClosedOnReceiveTopology(DiscoveryGroup discoveryGroup);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -686,6 +686,8 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
                   // We always try to connect here with only one attempt,
                   // as we will perform the initial retry here, looking for all possible connectors
                   factory.connect(1, false);
+
+                  addFactory(factory);
                } finally {
                   removeFromConnecting(factory);
                }
@@ -739,11 +741,16 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // how the sendSubscription happens.
       // in case this ever changes.
       if (topology != null && !factory.waitForTopology(config.callTimeout, TimeUnit.MILLISECONDS)) {
+         factoryClosed(factory);
+
          factory.cleanup();
+
+         if (isClosed()) {
+            throw ActiveMQClientMessageBundle.BUNDLE.connectionClosedOnReceiveTopology(discoveryGroup);
+         }
+
          throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
       }
-
-      addFactory(factory);
 
       return factory;
    }


### PR DESCRIPTION
ServerLocatorImpl waits for topology after connecting a new session factory. It should interrupt waiting for topology when it is closed to fail fast.

(cherry picked from commit c47d15c12a9e26d7e8ce1f977c286562c15396e9)

Issue: https://issues.redhat.com/browse/JBEAP-6180