### PR TITLE
ARTEMIS-4302 NPE on JournalTransaction::forget 

### DIFF
--- a/artemis-journal/pom.xml
+++ b/artemis-journal/pom.xml
@@ -85,5 +85,10 @@
          <artifactId>junit</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 </project>

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
@@ -353,12 +353,13 @@ public class JournalTransaction {
     * Used by load, when the transaction was not loaded correctly
     */
    public void forget() {
-      // The transaction was not committed or rolled back in the file, so we
-      // reverse any pos counts we added
-      for (JournalFile jf : pendingFiles) {
-         jf.decPosCount();
+      if (pendingFiles != null) {
+         // The transaction was not committed or rolled back in the file, so we
+         // reverse any pos counts we added
+         for (JournalFile jf : pendingFiles) {
+            jf.decPosCount();
+         }
       }
-
    }
 
    @Override

--- a/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/JournalTransactionForget.java
+++ b/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/JournalTransactionForget.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.journal.impl;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JournalTransactionForget {
+   @Test
+   public void testForgetTX() {
+      JournalTransaction transaction = new JournalTransaction(1, Mockito.mock(JournalRecordProvider.class));
+      transaction.forget();
+   }
+}

--- a/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/JournalTransactionForgetTest.java
+++ b/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/JournalTransactionForgetTest.java
@@ -14,29 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.activemq.artemis.core.journal.impl;
 
-import org.apache.activemq.artemis.utils.SpawnedVMSupport;
-import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-public class VerifyUpdateFactorSystemProperty {
-
-   public static void main(String[] arg) {
-
-      try {
-         Assert.assertEquals(33.0, JournalImpl.UPDATE_FACTOR, 0);
-         System.exit(0);
-      } catch (Throwable e) {
-         e.printStackTrace();
-         System.exit(100);
-      }
-   }
-
+public class JournalTransactionForgetTest {
    @Test
-   public void testValidateUpdateRecordProperty() throws Exception {
-      Process process = SpawnedVMSupport.spawnVM(VerifyUpdateFactorSystemProperty.class.getName(), new String[]{"-D" + JournalImpl.class.getName() + ".UPDATE_FACTOR=33.0"}, new String[]{});
-      Assert.assertEquals(0, process.waitFor());
+   public void testForgetTX() {
+      JournalTransaction transaction = new JournalTransaction(1, Mockito.mock(JournalRecordProvider.class));
+      transaction.forget();
    }
-
 }

--- a/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/VerifyUpdateFactorSystemPropertyTest.java
+++ b/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/VerifyUpdateFactorSystemPropertyTest.java
@@ -14,16 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.activemq.artemis.core.journal.impl;
 
+import org.apache.activemq.artemis.utils.SpawnedVMSupport;
+import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-public class JournalTransactionForget {
-   @Test
-   public void testForgetTX() {
-      JournalTransaction transaction = new JournalTransaction(1, Mockito.mock(JournalRecordProvider.class));
-      transaction.forget();
+public class VerifyUpdateFactorSystemPropertyTest {
+
+   public static void main(String[] arg) {
+
+      try {
+         Assert.assertEquals(33.0, JournalImpl.UPDATE_FACTOR, 0);
+         System.exit(0);
+      } catch (Throwable e) {
+         e.printStackTrace();
+         System.exit(100);
+      }
    }
+
+   @Test
+   public void testValidateUpdateRecordProperty() throws Exception {
+      Process process = SpawnedVMSupport.spawnVM(VerifyUpdateFactorSystemPropertyTest.class.getName(), new String[]{"-D" + JournalImpl.class.getName() + ".UPDATE_FACTOR=33.0"}, new String[]{});
+      Assert.assertEquals(0, process.waitFor());
+   }
+
 }


### PR DESCRIPTION
This backports ARTEMIS-4302 to LTS branch 2.21.0.jbossorg-x for EAP 8.0 Update 1

JBEAP issue: https://issues.redhat.com/browse/JBEAP-25252

LTS 7.10 ENTMQBR issue: https://issues.redhat.com/browse/ENTMQBR-8489

Upstream PR: https://github.com/apache/activemq-artemis/pull/4499
Upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-4302

downstream PR: https://github.com/rh-messaging/activemq-artemis/pull/618 already fixed in EAP 7.4.13 (Artemis 2.16.0.redhat-00049)