### PR TITLE
[ARTEMIS-5085][JBEAP-28747] retryIntervalMultiplier Parameter Not Applied as Expected in Artemis AMQ Reconnect Attempts

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -875,14 +875,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                if (waitForRetry(interval))
                   return;
 
-               // Exponential back-off
-               long newInterval = (long) (interval * retryIntervalMultiplier);
-
-               if (newInterval > maxRetryInterval) {
-                  newInterval = maxRetryInterval;
-               }
-
-               interval = newInterval;
+               interval = serverLocator.getNextRetryInterval(interval, retryIntervalMultiplier, maxRetryInterval);
             } else {
                logger.debug("Could not connect to any server. Didn't have reconnection configured on the ClientSessionFactory");
                return;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorInternal.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorInternal.java
@@ -87,4 +87,6 @@ public interface ServerLocatorInternal extends ServerLocator {
    ClientProtocolManager newProtocolManager();
 
    boolean isConnectable();
+
+   long getNextRetryInterval(long retryInterval, double retryIntervalMultiplier, long maxRetryInterval);
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InitialConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InitialConnectionTest.java
@@ -76,4 +76,42 @@ public class InitialConnectionTest extends ActiveMQTestBase {
       long timeEnd = System.currentTimeMillis();
       Assert.assertTrue("3 connectors, at 100 milliseconds each try, initialConnectAttempt=2, it should have waited at least 600 (- 100 from the last try that we don't actually wait, just throw ) milliseconds", timeEnd - timeStart >= 500);
    }
+
+   @Test
+   public void testRetryIntervalMultiplier() {
+      int interval = 100;
+      double multiplier = 10.0;
+      int attempts = 3;
+      ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61610?retryInterval=" + interval + "&retryIntervalMultiplier=" + multiplier + "&initialConnectAttempts=" + attempts);
+      long timeStart = System.currentTimeMillis();
+      try {
+         connectionFactory.createConnection();
+         fail("Creating connection here should have failed");
+      } catch (JMSException e) {
+         // expected
+      }
+      long duration = System.currentTimeMillis() - timeStart;
+      long toWait = 1100;
+      Assert.assertTrue("Waited only " + duration + "ms, but should have waiting " + toWait,duration >= toWait);
+   }
+
+   @Test
+   public void testMaxRetryInterval() {
+      int interval = 100;
+      double multiplier = 50.0;
+      int attempts = 3;
+      int maxInterval = 1000;
+      ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61610?retryInterval=" + interval + "&retryIntervalMultiplier=" + multiplier + "&initialConnectAttempts=" + attempts + "&maxRetryInterval=" + maxInterval);
+      long timeStart = System.currentTimeMillis();
+      try {
+         connectionFactory.createConnection();
+         fail("Creating connection here should have failed");
+      } catch (JMSException e) {
+         // expected
+      }
+      long duration = System.currentTimeMillis() - timeStart;
+      long toWait = 1100;
+      Assert.assertTrue("Waited only " + duration + "ms, but should have waited " + toWait, duration >= toWait);
+      Assert.assertTrue("Waited " + duration + "ms, but should have only waited " + (toWait + 500), duration <= toWait + 500);
+   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-28747
https://issues.apache.org/jira/browse/ARTEMIS-5085

Backport of: https://github.com/apache/activemq-artemis/pull/5281