### PR TITLE
[JBEAP-33418] ARTEMIS-5773 Memory and storage leak in PostOfficeImpl and PagingManagerImpl

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -904,6 +904,9 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          }
 
          removeRetroactiveResources(address);
+
+         deleteDuplicateCache(address);
+
          if (server.hasBrokerAddressPlugins()) {
             server.callBrokerAddressPlugins(plugin -> plugin.afterRemoveAddress(address, addressInfo));
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoDeleteAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoDeleteAddressTest.java
@@ -75,6 +75,19 @@ public class AutoDeleteAddressTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testDuplicateIdCacheDeletedWithAddress() throws Exception {
+      // auto-delete-addresses defaults to true
+      server.createQueue(QueueConfiguration.of(queueA).setAddress(addressA).setRoutingType(RoutingType.ANYCAST).setAutoCreated(true));
+      // this will create a duplicate ID cache for this address without actually having to send a message with a duplicate ID
+      server.getPostOffice().getDuplicateIDCache(addressA);
+      assertNotNull(((PostOfficeImpl) server.getPostOffice()).getDuplicateIDCaches().get(addressA));
+      assertNotNull(server.getAddressInfo(addressA));
+      cf.createSession().createConsumer(queueA).close();
+      PostOfficeTestAccessor.sweepAndReapAddresses((PostOfficeImpl) server.getPostOffice());
+      Wait.assertNull(() -> ((PostOfficeImpl) server.getPostOffice()).getDuplicateIDCaches().get(addressA), 500, 50);
+   }
+
+   @Test
    public void testNegativeAutoDeleteAutoCreatedAddress() throws Exception {
       server.getAddressSettingsRepository().addMatch(addressA.toString(), new AddressSettings().setAutoDeleteAddresses(false));
       server.createQueue(QueueConfiguration.of(queueA).setAddress(addressA).setRoutingType(RoutingType.ANYCAST).setAutoCreated(true));


### PR DESCRIPTION
Issue: [JBEAP-33418](https://redhat.atlassian.net/browse/JBEAP-33418)

Backporting fix for ARTEMIS-5773 to resolve duplicate ID cache leak on auto-delete addresses.

(cherry picked from commit 6947bd502586311207ff8f1fe55f80c09363714c)

downstream: [ENTMQBR-11091](https://redhat.atlassian.net/browse/ENTMQBR-11091)  / [ JBEAP-33418](https://redhat.atlassian.net/browse/JBEAP-33418)